### PR TITLE
Added converter for Tonto basis set format

### DIFF
--- a/basis_set_exchange/api.py
+++ b/basis_set_exchange/api.py
@@ -136,6 +136,7 @@ def get_basis(name,
             * gamess_us
             * turbomole
             * json
+            * tonto
 
     uncontract_general : bool
         If True, remove general contractions by duplicating the set

--- a/basis_set_exchange/converters/convert.py
+++ b/basis_set_exchange/converters/convert.py
@@ -8,6 +8,7 @@ from .g94 import write_g94
 from .gamess_us import write_gamess_us
 from .psi4 import write_psi4
 from .turbomole import write_turbomole
+from .tonto import write_tonto
 from .molpro import write_molpro
 from .cfour import write_cfour
 from .bsedebug import write_bsedebug
@@ -47,6 +48,13 @@ _converter_map = {
         'comment': '#',
         'valid': set(['cartesian_gto', 'spherical_gto', 'scalar_ecp']),
         'function': write_turbomole
+    },
+    'tonto': {
+        'display': 'tonto',
+        'extension': '.tm',
+        'comment': '#',
+        'valid': set(['cartesian_gto']),
+        'function': write_tonto
     },
     'molpro': {
         'display': 'Molpro',
@@ -101,10 +109,17 @@ def convert_basis(basis_dict, fmt, header=None):
     # Actually do the conversion
     ret_str = converter['function'](basis_dict)
 
-    if header is not None and fmt != 'json':
+    if header is not None and fmt != 'json' and fmt != 'tonto':
         comment_str = _converter_map[fmt]['comment']
         header_str = comment_str + comment_str.join(header.splitlines(True))
         ret_str = header_str + '\n\n' + ret_str
+
+    if fmt == 'tonto' :
+        harm_type = 'cartesian'
+        if header is not None :
+           comment_str = '!'
+           header_str = comment_str + comment_str.join(header.splitlines(True))
+           ret_str = header_str + '\n\n' + ret_str
 
     # HACK - Psi4 requires the first non-comment line be spherical/cartesian
     #        so we have to add that before the header

--- a/basis_set_exchange/converters/tonto.py
+++ b/basis_set_exchange/converters/tonto.py
@@ -1,0 +1,93 @@
+'''
+Conversion of basis sets to Turbomole format
+'''
+
+from .. import lut, manip, sort, printing
+
+
+def write_tonto(basis):
+    '''Converts a basis set to Tonto format
+    '''
+
+    s = '' + '\n'
+    s += ' keys= { turbomole }' + '\n'
+    s += '\n'
+    s += '   data= {' + '\n'
+    s += '\n'
+
+    # TM basis sets are completely uncontracted
+    basis = manip.uncontract_general(basis, True)
+    basis = manip.uncontract_spdf(basis, 0, False)
+    basis = sort.sort_basis(basis, False)
+
+    # Elements for which we have electron basis
+    electron_elements = [k for k, v in basis['elements'].items() if 'electron_shells' in v]
+
+    # Elements for which we have ECP
+    ecp_elements = [k for k, v in basis['elements'].items() if 'ecp_potentials' in v]
+
+    # Electron Basis
+    if len(electron_elements) > 0:
+        for z in electron_elements:
+            data = basis['elements'][z]
+            sym = lut.element_sym_from_Z(z, False)
+            s += '      {}:{}\n'.format(sym, basis['name'])
+            s += '      {\n'
+
+            for shell in data['electron_shells']:
+                exponents = shell['exponents']
+                coefficients = shell['coefficients']
+                ncol = len(coefficients) + 1
+                nprim = len(exponents)
+
+                am = shell['angular_momentum']
+                amchar = lut.amint_to_char(am, hij=True)
+                s += '             {}   {}\n'.format(nprim, amchar)
+
+                point_places = [11 * i + 15 * (i - 1) for i in range(1, ncol + 1)]
+                s += printing.write_matrix([exponents, *coefficients], point_places, convert_exp=True)
+
+            s += '      }\n'
+            s += '\n'
+
+    # Write out ECP
+    if len(ecp_elements) > 0:
+        s += '$ecp\n'
+        s += '*\n'
+        for z in ecp_elements:
+            data = basis['elements'][z]
+            sym = lut.element_sym_from_Z(z)
+            s += '{} {}-ecp\n'.format(sym, basis['name'])
+            s += '*\n'
+
+            max_ecp_am = max([x['angular_momentum'][0] for x in data['ecp_potentials']])
+            max_ecp_amchar = lut.amint_to_char([max_ecp_am], hij=True)
+
+            # Sort lowest->highest, then put the highest at the beginning
+            ecp_list = sorted(data['ecp_potentials'], key=lambda x: x['angular_momentum'])
+            ecp_list.insert(0, ecp_list.pop())
+
+            s += '  ncore = {}   lmax = {}\n'.format(data['ecp_electrons'], max_ecp_am)
+
+            for pot in ecp_list:
+                rexponents = pot['r_exponents']
+                gexponents = pot['gaussian_exponents']
+                coefficients = pot['coefficients']
+
+                am = pot['angular_momentum']
+                amchar = lut.amint_to_char(am, hij=True)
+
+                if am[0] == max_ecp_am:
+                    s += '{}\n'.format(amchar)
+                else:
+                    s += '{}-{}\n'.format(amchar, max_ecp_amchar)
+
+                point_places = [9, 23, 32]
+                s += printing.write_matrix([*coefficients, rexponents, gexponents], point_places, convert_exp=True)
+            s += '\n'
+
+    s += '   }\n'
+    s += '\n'
+    s += '}\n'
+
+    return s


### PR DESCRIPTION
Added one extra converter for Tonto format. The changes are very small as Tonto uses a slightly modified format than the ones already available (only in special characters, a loop header that tonto needs to read in the file and comment strings).