### PR TITLE
Update URLs [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This library is used to form the backend of the new Basis Set Exchange
 website.
 
 This project is a collaboration between the Molecular Sciences Software
-Institute (http://www.molssi.org) and the Environmental Molecular Sciences
+Institute (https://molssi.org) and the Environmental Molecular Sciences
 Laboratory (https://www.emsl.pnl.gov)
 
 ## Citation

--- a/basis_set_exchange/bundle.py
+++ b/basis_set_exchange/bundle.py
@@ -32,7 +32,7 @@ Basis set notes have a .notes extension, and family
 notes have a .family_notes extension.
 
 -------------------------------------------------
-https://wwww.basissetexchange.org
+https://www.basissetexchange.org
 https://github.com/MolSSI-BSE/basis_set_exchange
 bse@molssi.org
 -------------------------------------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -4,7 +4,7 @@
 #
 # This file does only contain a selection of the most common options. For a
 # full list see the documentation:
-# http://www.sphinx-doc.org/en/master/config
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 # -- Path setup --------------------------------------------------------------
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,8 +10,8 @@ This project is the data repository for basis sets found in quantum
 chemistry, plus a library for reading and manipulating the basis sets.
 
 This library is written as part of a rewrite of the Basis Set Exchange
-(https://bse.pnl.gov/bse/portal) and is a collaboration between the
-Molecular Sciences Software Institute (http://www.molssi.org) and the
+(https://www.basissetexchange.org) and is a collaboration between the
+Molecular Sciences Software Institute (https://molssi.org) and the
 Environmental Molecular Sciences Laboratory (https://www.emsl.pnl.gov)
 
 The code for this project is located on GitHub at

--- a/doc/project_doc.rst
+++ b/doc/project_doc.rst
@@ -7,7 +7,7 @@ project.
 
 Goal
 -------------------
-A rewrite of the current EMSL Basis Set Exchange database and website (https://bse.pnl.gov/bse/portal)
+A rewrite of the current EMSL Basis Set Exchange database and website (https://www.basissetexchange.org)
 
 
 Public Code Repository

--- a/versioneer.py
+++ b/versioneer.py
@@ -1752,7 +1752,7 @@ def do_setup():
     except EnvironmentError:
         pass
     # That doesn't cover everything MANIFEST.in can do
-    # (http://docs.python.org/2/distutils/sourcedist.html#commands), so
+    # (https://docs.python.org/2/distutils/sourcedist.html#commands), so
     # it might give some false negatives. Appending redundant 'include'
     # lines is safe, though.
     if "versioneer.py" not in simple_includes:


### PR DESCRIPTION
- replace bse.pnl.gov/bse/portal with www.basissetexchange.org
- use https if possible
- note: http://www.ipc.uni-karlsruhe.de/tch/tch1/index.html is dead