### PR TITLE
Force importlib_metadata < 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,9 +49,11 @@ if __name__ == "__main__":
         },
         install_requires=[
             'jsonschema',
-            'argcomplete'
+            'argcomplete',
         ],
         extras_require={
+            ':python_version == "3.6"': ["importlib-metadata < 3"],
+            ':python_version == "3.7"': ["importlib-metadata < 3"],
             'docs': [
                 'sphinx',
                 'sphinxcontrib-programoutput',


### PR DESCRIPTION
The current pip resolver still pulls in `importlib_metadata` 3.0 even though it is restricted by argcomplete. So force the package constraint at the top.

This should be revisited when either the constraint is lifted on argcomplete, or the pip resolver gains some semblance of sanity.