### PR TITLE
Specify angular momentum type in Molpro output

### DIFF
--- a/basis_set_exchange/writers/molpro.py
+++ b/basis_set_exchange/writers/molpro.py
@@ -14,7 +14,10 @@ def write_molpro(basis):
     basis = manip.make_general(basis, False, True)
     basis = sort.sort_basis(basis, True)
 
-    s = ''
+    # Start out with angular momentum type
+    types = basis['function_types']
+    harm_type = 'cartesian' if 'gto_cartesian' in types else 'spherical'
+    s = harm_type + '\n'
 
     # Elements for which we have electron basis
     electron_elements = [k for k, v in basis['elements'].items() if 'electron_shells' in v]

--- a/basis_set_exchange/writers/write.py
+++ b/basis_set_exchange/writers/write.py
@@ -205,7 +205,7 @@ def write_formatted_basis_str(basis_dict, fmt, header=None):
     #        so we have to add that before the header
     if fmt == 'psi4':
         types = basis_dict['function_types']
-        harm_type = 'spherical' if 'gto_spherical' in types else 'cartesian'
+        harm_type = 'cartesian' if 'gto_cartesian' in types else 'spherical'
         ret_str = harm_type + '\n\n' + ret_str
 
     return ret_str


### PR DESCRIPTION
Molpro output didn't specify angular momentum type, which leads to wrong results.

Also, the Psi4 check was in the wrong order IMHO, since it lead to e.g. 6-31G** given in spherical form #158. Switching around the check to prefer cartesian form fixes that issue.