### PR TITLE
Update list of used function types in get_basis

### DIFF
--- a/basis_set_exchange/api.py
+++ b/basis_set_exchange/api.py
@@ -215,6 +215,10 @@ def get_basis(name,
             # Set to only the elements we want
             basis_dict['elements'] = {k: v for k, v in bs_elements.items() if k in elements}
 
+            # Since we only grab some of the elements, we need to
+            # update the function types used, too
+            basis_dict['function_types'] = compose._whole_basis_types(basis_dict)
+
     # Note that from now on, the pipleline is going to modify basis_dict. That is ok,
     # since we are returned a unique instance from compose_table_basis
 


### PR DESCRIPTION
If only a subset of elements is requested, the list of used functions needs to be updated.

This is a partial fix to #158.