### PR TITLE
Prune basis in make_general to avoid duplicate exponents (#166)

### DIFF
--- a/basis_set_exchange/manip.py
+++ b/basis_set_exchange/manip.py
@@ -381,6 +381,10 @@ def make_general(basis, skip_spdf=False, use_copy=True):
 
         el['electron_shells'] = newshells
 
+    # If the basis was read in from a segmented format, it will have
+    # duplicate primitives, and so a pruning is necessary
+    prune_basis(basis, False)
+
     return basis
 
 


### PR DESCRIPTION
This PR runs `prune_basis` in `make_general`, which eliminates any duplicate exponents from the basis set. This is important for conversion of basis sets, since reading in a basis in a segmented format otherwise leads to duplication of exponents in several basis set output formats.

Closes #166