### PR TITLE
Implement AutoAux and auto-ABS methods for automatic formation of auxiliary basis sets

### DIFF
--- a/basis_set_exchange/api.py
+++ b/basis_set_exchange/api.py
@@ -102,6 +102,7 @@ def get_basis(name,
               optimize_general=False,
               augment_diffuse=0,
               augment_steep=0,
+              get_aux=0,
               data_dir=None,
               header=True):
     '''Obtain a basis set
@@ -164,6 +165,10 @@ def get_basis(name,
         Add n diffuse functions by even-tempered extrapolation
     augment_steep : int
         Add n steep functions by even-tempered extrapolation
+    get_aux : int
+        Instead of the orbital basis, get an auxiliary basis
+        set. Options 0 (return orbital basis), 1 (return AutoAux
+        basis), 2 (return Auto-ABS Coulomb fitting basis)
     data_dir : str
         Data directory with all the basis set information. By default,
         it is in the 'data' subdirectory of this project.
@@ -173,6 +178,7 @@ def get_basis(name,
     str or dict
         The basis set in the desired format. If `fmt` is **None**, this will be a python
         dictionary. Otherwise, it will be a string.
+
     '''
 
     data_dir = fix_data_dir(data_dir)
@@ -271,6 +277,12 @@ def get_basis(name,
     # Re-make general
     if (augment_diffuse > 0 or augment_steep > 0) and make_general:
         basis_dict = manip.make_general(basis_dict, False, False)
+
+    # Did we actually want an auxiliary basis set?
+    if get_aux == 1:
+        basis_dict = manip.autoaux_basis(basis_dict)
+    elif get_aux == 2:
+        basis_dict = manip.autoabs_basis(basis_dict)
 
     # If fmt is not specified, return as a python dict
     if fmt is None:

--- a/basis_set_exchange/cli/bse_cli.py
+++ b/basis_set_exchange/cli/bse_cli.py
@@ -105,6 +105,24 @@ def run_bse_cli():
     subp.add_argument('--aug-steep', type=int, default=0, help='Augment with n steep functions')
     subp.add_argument('--aug-diffuse', type=int, default=0, help='Augment with n diffuse functions')
 
+    # get-autoaux-basis subcommand
+    subp = subparsers.add_parser('get-autoaux-basis', help='Output an automatic auxiliary basis')
+    subp.add_argument('basis', help='Name of the basis set to output').completer = cli_bsname_completer
+    subp.add_argument('fmt',
+                      help='Which format to output the auxiliary basis set as').completer = cli_write_fmt_completer
+    subp.add_argument('--elements',
+                      help='Which elements of the basis set to output. Default is all defined in the given basis')
+    subp.add_argument('--version', help='Which version of the basis set to output. Default is the latest version')
+    subp.add_argument('--noheader', action='store_true', help='Do not output the header at the top')
+    subp.add_argument('--unc-gen', action='store_true', help='Remove general contractions')
+    subp.add_argument('--unc-spdf', action='store_true', help='Remove combined sp, spd, ... contractions')
+    subp.add_argument('--unc-seg', action='store_true', help='Remove general contractions')
+    subp.add_argument('--rm-free', action='store_true', help='Remove free primitives')
+    subp.add_argument('--opt-gen', action='store_true', help='Optimize general contractions')
+    subp.add_argument('--make-gen', action='store_true', help='Make the basis set as generally-contracted as possible')
+    subp.add_argument('--aug-steep', type=int, default=0, help='Augment with n steep functions')
+    subp.add_argument('--aug-diffuse', type=int, default=0, help='Augment with n diffuse functions')
+
     # get-refs subcommand
     subp = subparsers.add_parser('get-refs', help='Output references for a basis set')
     subp.add_argument('basis',

--- a/basis_set_exchange/cli/bse_cli.py
+++ b/basis_set_exchange/cli/bse_cli.py
@@ -154,6 +154,29 @@ def run_bse_cli():
         help='Output format (default: autodetected from output filename').completer = cli_write_fmt_completer
 
     #################################
+    # Auxiliary basis sets
+    #################################
+    subp = subparsers.add_parser('autoaux-basis', help='Form AutoAux auxiliary basis')
+    subp.add_argument('input_file', type=str, help='Orbital basis to load')
+    subp.add_argument('output_file', type=str, help='AutoAux basis to write')
+    subp.add_argument(
+        '--in-fmt', type=str, default=None,
+        help='Input format (default: autodetected from input filename').completer = cli_read_fmt_completer
+    subp.add_argument(
+        '--out-fmt', type=str, default=None,
+        help='Output format (default: autodetected from output filename').completer = cli_write_fmt_completer
+
+    subp = subparsers.add_parser('autoabs-basis', help='Form AutoABS auxiliary basis')
+    subp.add_argument('input_file', type=str, help='Orbital basis to load')
+    subp.add_argument('output_file', type=str, help='AutoABS basis to write')
+    subp.add_argument(
+        '--in-fmt', type=str, default=None,
+        help='Input format (default: autodetected from input filename').completer = cli_read_fmt_completer
+    subp.add_argument(
+        '--out-fmt', type=str, default=None,
+        help='Output format (default: autodetected from output filename').completer = cli_write_fmt_completer
+
+    #################################
     # Creating bundles
     #################################
     subp = subparsers.add_parser('create-bundle', help='Create a bundle of basis sets')

--- a/basis_set_exchange/cli/bse_cli.py
+++ b/basis_set_exchange/cli/bse_cli.py
@@ -104,42 +104,10 @@ def run_bse_cli():
     subp.add_argument('--make-gen', action='store_true', help='Make the basis set as generally-contracted as possible')
     subp.add_argument('--aug-steep', type=int, default=0, help='Augment with n steep functions')
     subp.add_argument('--aug-diffuse', type=int, default=0, help='Augment with n diffuse functions')
-
-    # get-autoaux-basis subcommand
-    subp = subparsers.add_parser('get-autoaux-basis', help='Output an automatic auxiliary basis')
-    subp.add_argument('basis', help='Name of the basis set to output').completer = cli_bsname_completer
-    subp.add_argument('fmt',
-                      help='Which format to output the auxiliary basis set as').completer = cli_write_fmt_completer
-    subp.add_argument('--elements',
-                      help='Which elements of the basis set to output. Default is all defined in the given basis')
-    subp.add_argument('--version', help='Which version of the basis set to output. Default is the latest version')
-    subp.add_argument('--noheader', action='store_true', help='Do not output the header at the top')
-    subp.add_argument('--unc-gen', action='store_true', help='Remove general contractions')
-    subp.add_argument('--unc-spdf', action='store_true', help='Remove combined sp, spd, ... contractions')
-    subp.add_argument('--unc-seg', action='store_true', help='Remove general contractions')
-    subp.add_argument('--rm-free', action='store_true', help='Remove free primitives')
-    subp.add_argument('--opt-gen', action='store_true', help='Optimize general contractions')
-    subp.add_argument('--make-gen', action='store_true', help='Make the basis set as generally-contracted as possible')
-    subp.add_argument('--aug-steep', type=int, default=0, help='Augment with n steep functions')
-    subp.add_argument('--aug-diffuse', type=int, default=0, help='Augment with n diffuse functions')
-
-    # get-autoabs-basis subcommand
-    subp = subparsers.add_parser('get-autoabs-basis', help='Output an automatic Coulomb fitting basis set')
-    subp.add_argument('basis', help='Name of the basis set to output').completer = cli_bsname_completer
-    subp.add_argument('fmt',
-                      help='Which format to output the auxiliary basis set as').completer = cli_write_fmt_completer
-    subp.add_argument('--elements',
-                      help='Which elements of the basis set to output. Default is all defined in the given basis')
-    subp.add_argument('--version', help='Which version of the basis set to output. Default is the latest version')
-    subp.add_argument('--noheader', action='store_true', help='Do not output the header at the top')
-    subp.add_argument('--unc-gen', action='store_true', help='Remove general contractions')
-    subp.add_argument('--unc-spdf', action='store_true', help='Remove combined sp, spd, ... contractions')
-    subp.add_argument('--unc-seg', action='store_true', help='Remove general contractions')
-    subp.add_argument('--rm-free', action='store_true', help='Remove free primitives')
-    subp.add_argument('--opt-gen', action='store_true', help='Optimize general contractions')
-    subp.add_argument('--make-gen', action='store_true', help='Make the basis set as generally-contracted as possible')
-    subp.add_argument('--aug-steep', type=int, default=0, help='Augment with n steep functions')
-    subp.add_argument('--aug-diffuse', type=int, default=0, help='Augment with n diffuse functions')
+    subp.add_argument('--get-aux',
+                      type=int,
+                      default=0,
+                      help='Instead of the orbital basis, get an automatically formed auxiliary basis')
 
     # get-refs subcommand
     subp = subparsers.add_parser('get-refs', help='Output references for a basis set')

--- a/basis_set_exchange/cli/bse_cli.py
+++ b/basis_set_exchange/cli/bse_cli.py
@@ -123,6 +123,24 @@ def run_bse_cli():
     subp.add_argument('--aug-steep', type=int, default=0, help='Augment with n steep functions')
     subp.add_argument('--aug-diffuse', type=int, default=0, help='Augment with n diffuse functions')
 
+    # get-autoabs-basis subcommand
+    subp = subparsers.add_parser('get-autoabs-basis', help='Output an automatic Coulomb fitting basis set')
+    subp.add_argument('basis', help='Name of the basis set to output').completer = cli_bsname_completer
+    subp.add_argument('fmt',
+                      help='Which format to output the auxiliary basis set as').completer = cli_write_fmt_completer
+    subp.add_argument('--elements',
+                      help='Which elements of the basis set to output. Default is all defined in the given basis')
+    subp.add_argument('--version', help='Which version of the basis set to output. Default is the latest version')
+    subp.add_argument('--noheader', action='store_true', help='Do not output the header at the top')
+    subp.add_argument('--unc-gen', action='store_true', help='Remove general contractions')
+    subp.add_argument('--unc-spdf', action='store_true', help='Remove combined sp, spd, ... contractions')
+    subp.add_argument('--unc-seg', action='store_true', help='Remove general contractions')
+    subp.add_argument('--rm-free', action='store_true', help='Remove free primitives')
+    subp.add_argument('--opt-gen', action='store_true', help='Optimize general contractions')
+    subp.add_argument('--make-gen', action='store_true', help='Make the basis set as generally-contracted as possible')
+    subp.add_argument('--aug-steep', type=int, default=0, help='Augment with n steep functions')
+    subp.add_argument('--aug-diffuse', type=int, default=0, help='Augment with n diffuse functions')
+
     # get-refs subcommand
     subp = subparsers.add_parser('get-refs', help='Output references for a basis set')
     subp.add_argument('basis',

--- a/basis_set_exchange/cli/bse_handlers.py
+++ b/basis_set_exchange/cli/bse_handlers.py
@@ -138,6 +138,31 @@ def _bse_cli_get_autoaux_basis(args):
     return writers.write_formatted_basis_str(aux_basis, args.fmt)
 
 
+def _bse_cli_get_autoabs_basis(args):
+    '''Handles the get-autoabs-basis subcommand'''
+
+    aux_basis = manip.autoabs_basis(
+        api.get_basis(name=args.basis,
+                      elements=args.elements,
+                      version=args.version,
+                      fmt=None,
+                      uncontract_general=args.unc_gen,
+                      uncontract_spdf=args.unc_spdf,
+                      uncontract_segmented=args.unc_seg,
+                      remove_free_primitives=args.rm_free,
+                      make_general=args.make_gen,
+                      optimize_general=args.opt_gen,
+                      augment_diffuse=args.aug_diffuse,
+                      augment_steep=args.aug_steep,
+                      data_dir=args.data_dir,
+                      header=not args.noheader))
+
+    if args.fmt is None:
+        return aux_basis
+
+    return writers.write_formatted_basis_str(aux_basis, args.fmt)
+
+
 def _bse_cli_get_refs(args):
     '''Handles the get-refs subcommand'''
     return api.get_references(basis_name=args.basis,
@@ -242,6 +267,7 @@ def bse_cli_handle_subcmd(args):
         'list-families': _bse_cli_list_families,
         'lookup-by-role': _bse_cli_lookup_by_role,
         'get-basis': _bse_cli_get_basis,
+        'get-autoabs-basis': _bse_cli_get_autoabs_basis,
         'get-autoaux-basis': _bse_cli_get_autoaux_basis,
         'get-refs': _bse_cli_get_refs,
         'get-info': _bse_cli_get_info,

--- a/basis_set_exchange/cli/bse_handlers.py
+++ b/basis_set_exchange/cli/bse_handlers.py
@@ -2,7 +2,7 @@
 Handlers for command line subcommands
 '''
 
-from .. import api, bundle, readers, writers, refconverters, convert
+from .. import api, bundle, readers, writers, refconverters, convert, manip
 from ..misc import compact_elements
 from .common import format_columns
 
@@ -113,6 +113,31 @@ def _bse_cli_get_basis(args):
                          header=not args.noheader)
 
 
+def _bse_cli_get_autoaux_basis(args):
+    '''Handles the get-autoaux-basis subcommand'''
+
+    aux_basis = manip.autoaux_basis(
+        api.get_basis(name=args.basis,
+                      elements=args.elements,
+                      version=args.version,
+                      fmt=None,
+                      uncontract_general=args.unc_gen,
+                      uncontract_spdf=args.unc_spdf,
+                      uncontract_segmented=args.unc_seg,
+                      remove_free_primitives=args.rm_free,
+                      make_general=args.make_gen,
+                      optimize_general=args.opt_gen,
+                      augment_diffuse=args.aug_diffuse,
+                      augment_steep=args.aug_steep,
+                      data_dir=args.data_dir,
+                      header=not args.noheader))
+
+    if args.fmt is None:
+        return aux_basis
+
+    return writers.write_formatted_basis_str(aux_basis, args.fmt)
+
+
 def _bse_cli_get_refs(args):
     '''Handles the get-refs subcommand'''
     return api.get_references(basis_name=args.basis,
@@ -217,6 +242,7 @@ def bse_cli_handle_subcmd(args):
         'list-families': _bse_cli_list_families,
         'lookup-by-role': _bse_cli_lookup_by_role,
         'get-basis': _bse_cli_get_basis,
+        'get-autoaux-basis': _bse_cli_get_autoaux_basis,
         'get-refs': _bse_cli_get_refs,
         'get-info': _bse_cli_get_info,
         'get-notes': _bse_cli_get_notes,

--- a/basis_set_exchange/cli/bse_handlers.py
+++ b/basis_set_exchange/cli/bse_handlers.py
@@ -2,7 +2,7 @@
 Handlers for command line subcommands
 '''
 
-from .. import api, bundle, readers, writers, refconverters, convert, manip
+from .. import api, bundle, readers, writers, refconverters, convert
 from ..misc import compact_elements
 from .common import format_columns
 

--- a/basis_set_exchange/cli/bse_handlers.py
+++ b/basis_set_exchange/cli/bse_handlers.py
@@ -2,7 +2,7 @@
 Handlers for command line subcommands
 '''
 
-from .. import api, bundle, readers, writers, refconverters, convert
+from .. import api, bundle, readers, writers, refconverters, convert, manip
 from ..misc import compact_elements
 from .common import format_columns
 
@@ -206,6 +206,43 @@ def _bse_cli_create_bundle(args):
     return "Created " + args.bundle_file
 
 
+def _bse_cli_convert_basis(args):
+    '''Handles the convert-basis subcommand'''
+
+    # We convert file -> file
+    convert.convert_formatted_basis_file(args.input_file, args.output_file, args.in_fmt, args.out_fmt)
+    return "Converted {} -> {}".format(args.input_file, args.output_file)
+
+
+def _bse_cli_autoaux_basis(args):
+    '''Handles the autoaux-basis subcommand'''
+
+    orbital_basis_dict = readers.read_formatted_basis_file(args.input_file, args.in_fmt)
+    # Initialize some fields that aren't initialized by the BSE reader
+    orbital_basis_dict['revision_description'] = ''
+    orbital_basis_dict['version'] = ''
+
+    # Generate the autoaux basis
+    autoaux_basis_dict = manip.autoaux_basis(orbital_basis_dict)
+    # Save it to the wanted file
+    writers.write_formatted_basis_file(autoaux_basis_dict, args.output_file, args.out_fmt)
+    return "Orbital basis {} -> AutoAux basis {}".format(args.input_file, args.output_file)
+
+
+def _bse_cli_autoabs_basis(args):
+    '''Handles the autoabs-basis subcommand'''
+
+    orbital_basis_dict = readers.read_formatted_basis_file(args.input_file, args.in_fmt)
+    # Initialize some fields that aren't initialized by the BSE reader
+    orbital_basis_dict['revision_description'] = ''
+    orbital_basis_dict['version'] = ''
+
+    # Generate the autoabs basis
+    autoabs_basis_dict = manip.autoabs_basis(orbital_basis_dict)
+    # Save it to the wanted file
+    writers.write_formatted_basis_file(autoabs_basis_dict, args.output_file, args.out_fmt)
+    return "Orbital basis {} -> AutoABS basis {}".format(args.input_file, args.output_file)
+
 def bse_cli_handle_subcmd(args):
     handler_map = {
         'list-formats': _bse_cli_list_writer_formats,
@@ -225,7 +262,9 @@ def bse_cli_handle_subcmd(args):
         'get-versions': _bse_cli_get_versions,
         'get-family-notes': _bse_cli_get_family_notes,
         'convert-basis': _bse_cli_convert_basis,
-        'create-bundle': _bse_cli_create_bundle
+        'create-bundle': _bse_cli_create_bundle,
+        'autoaux-basis': _bse_cli_autoaux_basis,
+        'autoabs-basis': _bse_cli_autoabs_basis
     }
 
     return handler_map[args.subcmd](args)

--- a/basis_set_exchange/cli/bse_handlers.py
+++ b/basis_set_exchange/cli/bse_handlers.py
@@ -109,58 +109,9 @@ def _bse_cli_get_basis(args):
                          optimize_general=args.opt_gen,
                          augment_diffuse=args.aug_diffuse,
                          augment_steep=args.aug_steep,
+                         get_aux=args.get_aux,
                          data_dir=args.data_dir,
                          header=not args.noheader)
-
-
-def _bse_cli_get_autoaux_basis(args):
-    '''Handles the get-autoaux-basis subcommand'''
-
-    aux_basis = manip.autoaux_basis(
-        api.get_basis(name=args.basis,
-                      elements=args.elements,
-                      version=args.version,
-                      fmt=None,
-                      uncontract_general=args.unc_gen,
-                      uncontract_spdf=args.unc_spdf,
-                      uncontract_segmented=args.unc_seg,
-                      remove_free_primitives=args.rm_free,
-                      make_general=args.make_gen,
-                      optimize_general=args.opt_gen,
-                      augment_diffuse=args.aug_diffuse,
-                      augment_steep=args.aug_steep,
-                      data_dir=args.data_dir,
-                      header=not args.noheader))
-
-    if args.fmt is None:
-        return aux_basis
-
-    return writers.write_formatted_basis_str(aux_basis, args.fmt)
-
-
-def _bse_cli_get_autoabs_basis(args):
-    '''Handles the get-autoabs-basis subcommand'''
-
-    aux_basis = manip.autoabs_basis(
-        api.get_basis(name=args.basis,
-                      elements=args.elements,
-                      version=args.version,
-                      fmt=None,
-                      uncontract_general=args.unc_gen,
-                      uncontract_spdf=args.unc_spdf,
-                      uncontract_segmented=args.unc_seg,
-                      remove_free_primitives=args.rm_free,
-                      make_general=args.make_gen,
-                      optimize_general=args.opt_gen,
-                      augment_diffuse=args.aug_diffuse,
-                      augment_steep=args.aug_steep,
-                      data_dir=args.data_dir,
-                      header=not args.noheader))
-
-    if args.fmt is None:
-        return aux_basis
-
-    return writers.write_formatted_basis_str(aux_basis, args.fmt)
 
 
 def _bse_cli_get_refs(args):
@@ -267,8 +218,6 @@ def bse_cli_handle_subcmd(args):
         'list-families': _bse_cli_list_families,
         'lookup-by-role': _bse_cli_lookup_by_role,
         'get-basis': _bse_cli_get_basis,
-        'get-autoabs-basis': _bse_cli_get_autoabs_basis,
-        'get-autoaux-basis': _bse_cli_get_autoaux_basis,
         'get-refs': _bse_cli_get_refs,
         'get-info': _bse_cli_get_info,
         'get-notes': _bse_cli_get_notes,

--- a/basis_set_exchange/ints.py
+++ b/basis_set_exchange/ints.py
@@ -146,6 +146,49 @@ def gto_overlap_contr(exps0, contr0, l):
     return _transform(contr, ovl)
 
 
+def _gto_R(exps, l):
+    '''Computes the <r> matrix for the given exponents, assuming the basis
+    functions are of the normalized spherical form r^l exp(-z r^2).
+
+    '''
+    assert (isinstance(l, int) and l >= 0)
+
+    def rval(a, b, l):
+        ab = 0.5 * (a + b)
+        sqrtab = sqrt(a * b)
+        return 1.0 / sqrt(sqrtab) * (sqrtab / ab)**(l + 2)
+
+    # Initialize memory
+    rmat = _zero_matrix(len(exps))
+    prefactor = gamma(l + 2) / (sqrt(2) * gamma(l + 3 / 2))
+    for i in range(len(exps)):
+        for j in range(i + 1):
+            rmat[i][j] = prefactor * rval(exps[i], exps[j], l)
+            rmat[j][i] = rmat[i][j]
+    return rmat
+
+
+def gto_R_contr(exps0, contr0, l):
+    '''Computes the r matrix in the contracted basis, assuming the basis
+    functions are of the spherical form r^l \sum_i c_i exp(-z_i r^2).
+    The function also takes care of proper normalization.
+
+    '''
+
+    # Convert exponents and contractions to floating point
+    exps = _to_float(exps0)
+    contr = _to_float(contr0)
+
+    # Get primitive integrals
+    rmat = _gto_R(exps, l)
+    ovl = _gto_overlap(exps, l)
+
+    # Normalize the contraction
+    contr = _normalize_contraction(contr, ovl)
+    # Transform to normalized contracted form
+    return _transform(contr, rmat)
+
+
 def _gto_Rsq(exps, l):
     '''Computes the r^2 matrix for the given exponents, assuming the basis
     functions are of the normalized spherical form r^l exp(-z r^2).

--- a/basis_set_exchange/lut.py
+++ b/basis_set_exchange/lut.py
@@ -332,3 +332,10 @@ def electron_shells_start(nelectrons, max_am=20):
     start.extend(range(5, max_am + 2))
 
     return start
+
+
+def function_type_from_am(shell_am, base_type, spherical_type):
+    if max(shell_am) <= 1:
+        return base_type
+    else:
+        return base_type + '_' + spherical_type

--- a/basis_set_exchange/manip.py
+++ b/basis_set_exchange/manip.py
@@ -922,7 +922,8 @@ more accurate) auxiliary sets.
         amax_aux = [None for _ in range(lmax_aux + 1)]
         for laux in range(lmax_aux + 1):
             if laux <= 2 * lval:
-                amax_aux[laux] = max(flaux[laux] * a_maxaux_eff[laux], a_maxaux_prim[laux])
+                # There's a typo in the paper, max instead of min
+                amax_aux[laux] = min(flaux[laux] * a_maxaux_eff[laux], a_maxaux_prim[laux])
             else:
                 amax_aux[laux] = a_maxaux_eff[laux]
 

--- a/basis_set_exchange/manip.py
+++ b/basis_set_exchange/manip.py
@@ -961,7 +961,10 @@ more accurate) auxiliary sets.
     auxbasis_bs['elements'] = auxbasis_data
     auxbasis_bs['function_types'] = compose._whole_basis_types(auxbasis_bs)
 
+    auxbasis_bs['revision_description'] = basis['revision_description']
+    auxbasis_bs['version'] = basis['version']
     auxbasis_bs['name'] = basis['name'] + '_autoaux'
+    auxbasis_bs['role'] = 'rifit'
 
     return auxbasis_bs
 
@@ -1082,6 +1085,9 @@ def autoabs_basis(basis, lmaxinc=1, fsam=1.5):
     auxbasis_bs['elements'] = auxbasis_data
     auxbasis_bs['function_types'] = compose._whole_basis_types(auxbasis_bs)
 
+    auxbasis_bs['revision_description'] = basis['revision_description']
+    auxbasis_bs['version'] = basis['version']
     auxbasis_bs['name'] = basis['name'] + '_autoabs'
+    auxbasis_bs['role'] = 'jfit'
 
     return auxbasis_bs

--- a/basis_set_exchange/manip.py
+++ b/basis_set_exchange/manip.py
@@ -913,8 +913,8 @@ more accurate) auxiliary sets.
         # Limit maximal angular momentum
         lmax_aux = min(max(2 * lval, lmax + linc), 2 * lmax)
 
-        # Values from Table I
-        flaux = [20, 4.0, 4.0, 3.5, 2.5, 2.0, 2.0]
+        # Values from Table I; factor 7.0 for P functions is missing in the paper
+        flaux = [20, 7.0, 4.0, 4.0, 3.5, 2.5, 2.0, 2.0]
         blaux_big = [1.8, 2.0, 2.2, 2.2, 2.2, 2.3, 3.0, 3.0]
         b_small = 1.8
 

--- a/basis_set_exchange/manip.py
+++ b/basis_set_exchange/manip.py
@@ -961,6 +961,8 @@ more accurate) auxiliary sets.
     auxbasis_bs['elements'] = auxbasis_data
     auxbasis_bs['function_types'] = compose._whole_basis_types(auxbasis_bs)
 
+    auxbasis_bs['name'] = basis['name'] + '_autoaux'
+
     return auxbasis_bs
 
 
@@ -1079,5 +1081,7 @@ def autoabs_basis(basis, lmaxinc=1, fsam=1.5):
     auxbasis_bs = skel.create_skel('component')
     auxbasis_bs['elements'] = auxbasis_data
     auxbasis_bs['function_types'] = compose._whole_basis_types(auxbasis_bs)
+
+    auxbasis_bs['name'] = basis['name'] + '_autoabs'
 
     return auxbasis_bs

--- a/basis_set_exchange/readers/dalton.py
+++ b/basis_set_exchange/readers/dalton.py
@@ -1,5 +1,5 @@
 import re
-from .. import lut
+from .. import lut, manip
 from . import helpers
 from .nwchem import _parse_ecp_lines
 
@@ -82,7 +82,7 @@ def _parse_electron_lines(basis_lines, bs_data):
         else:
             raise RuntimeError("Unable to parse block in dalton: header line is \"{}\"".format(header))
 
-        element_data = helpers.create_element_data(bs_data, element_Z, 'electron_shells')
+        element_data = manip.create_element_data(bs_data, element_Z, 'electron_shells')
         el_lines.pop(0)
 
         # Remove all the rest of the comment lines
@@ -107,7 +107,7 @@ def _parse_electron_lines(basis_lines, bs_data):
                     ]
             exponents, coefficients = helpers.parse_primitive_matrix(bas_lines, nprim=nprim, ngen=ngen)
 
-            func_type = helpers.function_type_from_am([shell_am], 'gto', 'spherical')
+            func_type = lut.function_type_from_am([shell_am], 'gto', 'spherical')
 
             shell = {
                 'function_type': func_type,

--- a/basis_set_exchange/readers/demon2k.py
+++ b/basis_set_exchange/readers/demon2k.py
@@ -1,7 +1,7 @@
 # Written by Susi Lehtola, 2021
 
 import re
-from .. import lut
+from .. import lut, manip
 from . import helpers
 
 # Orbital entry: O-ELEMENT [possible repetition(s) of element symbol] (name)
@@ -34,7 +34,7 @@ def _parse_electron_lines(basis_lines, bs_data):
 
     # Create basis
     element_Z = lut.element_Z_from_name(element_name, as_str=True)
-    element_data = helpers.create_element_data(bs_data, element_Z, 'electron_shells')
+    element_data = manip.create_element_data(bs_data, element_Z, 'electron_shells')
 
     # Second line is number of shells
     n_shells = int(basis_lines[1].split()[0])
@@ -58,7 +58,7 @@ def _parse_electron_lines(basis_lines, bs_data):
         exponents, coefficients = helpers.parse_primitive_matrix(sh_lines[1:1 + nprim], nprim, ngen)
 
         # Function type (assuming always spherical)
-        func_type = helpers.function_type_from_am(shell_am, 'gto', 'spherical')
+        func_type = lut.function_type_from_am(shell_am, 'gto', 'spherical')
         shell = {
             'function_type': func_type,
             'region': '',
@@ -91,7 +91,7 @@ def _parse_ecp_lines(ecp_lines, bs_data):
 
         # Initialize basis
         element_Z = lut.element_Z_from_sym(element_sym, as_str=True)
-        element_data = helpers.create_element_data(bs_data, element_Z, 'ecp_potentials')
+        element_data = manip.create_element_data(bs_data, element_Z, 'ecp_potentials')
         element_data['ecp_electrons'] = ecp_electrons
 
         # Read angular momentum blocks

--- a/basis_set_exchange/readers/g94.py
+++ b/basis_set_exchange/readers/g94.py
@@ -1,5 +1,5 @@
 import re
-from .. import lut
+from .. import lut, manip
 from . import helpers
 
 element_re = re.compile(r'^-?([A-Za-z]{1,3})(?:\s+0)?$')
@@ -32,7 +32,7 @@ def _parse_electron_lines(basis_lines, bs_data):
     element_sym = element_sym.lstrip('-')
 
     element_Z = lut.element_Z_from_sym(element_sym, as_str=True)
-    element_data = helpers.create_element_data(bs_data, element_Z, 'electron_shells')
+    element_data = manip.create_element_data(bs_data, element_Z, 'electron_shells')
 
     # After that come shells. We determine the start of a shell
     # by if the line starts with an angular momentum (a non-numeric character
@@ -43,7 +43,7 @@ def _parse_electron_lines(basis_lines, bs_data):
         shell_am, nprim, scaling_factors = helpers.parse_line_regex(am_line_re, sh_lines[0],
                                                                     "Shell AM, nprim, scaling")
         shell_am = lut.amchar_to_int(shell_am, hij=True)
-        func_type = helpers.function_type_from_am(shell_am, 'gto', 'spherical')
+        func_type = lut.function_type_from_am(shell_am, 'gto', 'spherical')
 
         # Handle gaussian scaling factors
         # The square of the scaling factor is applied to exponents.
@@ -111,7 +111,7 @@ def _parse_ecp_lines(basis_lines, bs_data):
     # First line is "{element} 0", with the zero being optional
     element_sym = basis_lines[0].split()[0]
     element_Z = lut.element_Z_from_sym(element_sym, as_str=True)
-    element_data = helpers.create_element_data(bs_data, element_Z, 'ecp_potentials')
+    element_data = manip.create_element_data(bs_data, element_Z, 'ecp_potentials')
 
     # Second line is information about the ECP
     max_am, ecp_electrons = helpers.parse_line_regex(ecp_am_nelec_re, basis_lines[1], 'ECP max_am, nelec')

--- a/basis_set_exchange/readers/gbasis.py
+++ b/basis_set_exchange/readers/gbasis.py
@@ -1,5 +1,5 @@
 import re
-from .. import lut
+from .. import lut, manip
 from . import helpers
 
 element_entry_re = re.compile(r'^([a-zA-Z]{1,3}):(.*):(.*)$')
@@ -37,7 +37,7 @@ def read_gbasis(basis_lines):
         # We only support one basis per file
         found_basis.add(basis_name)
 
-        element_data = helpers.create_element_data(bs_data, element_Z, 'electron_shells')
+        element_data = manip.create_element_data(bs_data, element_Z, 'electron_shells')
         max_am = helpers.parse_line_regex(r'^(\d+)$', element_lines[1], 'Highest AM')
 
         # Split all the shells based on lines beginning with alpha character
@@ -55,7 +55,7 @@ def read_gbasis(basis_lines):
             shell_am, nprim, ngen = helpers.parse_line_regex(shell_info_re, shell_lines[0], 'Shell: AM, nprim, ngen')
             shell_am = lut.amchar_to_int(shell_am)
 
-            func_type = helpers.function_type_from_am(shell_am, 'gto', 'spherical')
+            func_type = lut.function_type_from_am(shell_am, 'gto', 'spherical')
 
             if len(shell_am) > 1:
                 raise RuntimeError("Fused AM not supported by gbasis")

--- a/basis_set_exchange/readers/genbas.py
+++ b/basis_set_exchange/readers/genbas.py
@@ -1,5 +1,5 @@
 import re
-from .. import lut, misc
+from .. import lut, misc, manip
 from . import helpers
 from .turbomole import _parse_ecp_potential_lines
 
@@ -16,7 +16,7 @@ def _parse_electron_lines(basis_lines, bs_data):
     element_sym, _ = helpers.parse_line_regex(element_block_re, basis_lines[0])
     element_Z = lut.element_Z_from_sym(element_sym, as_str=True)
 
-    element_data = helpers.create_element_data(bs_data, element_Z, 'electron_shells')
+    element_data = manip.create_element_data(bs_data, element_Z, 'electron_shells')
 
     basis_lines = basis_lines[2:]
 
@@ -40,7 +40,7 @@ def _parse_electron_lines(basis_lines, bs_data):
         nprim = shell_nprims[shell_idx]
         ngen = shell_ngens[shell_idx]
 
-        func_type = helpers.function_type_from_am(shell_am, 'gto', 'spherical')
+        func_type = lut.function_type_from_am(shell_am, 'gto', 'spherical')
 
         # Read in exponents and coefficients
         # We know the dimensions of the coefficient matrix. That matrix
@@ -80,7 +80,7 @@ def _parse_ecp_lines(basis_lines, bs_data):
     #element_sym, _ = helpers.parse_line_regex(element_block_re, basis_lines[0])
     #element_Z = str(lut.element_Z_from_sym(element_sym))
 
-    #element_data = helpers.create_element_data(bs_data, element_Z, 'ecp_potentials')
+    #element_data = manip.create_element_data(bs_data, element_Z, 'ecp_potentials')
 
     # We can use the turbomole parser for ECP.
     # However, needs to be fixed

--- a/basis_set_exchange/readers/helpers.py
+++ b/basis_set_exchange/readers/helpers.py
@@ -49,13 +49,6 @@ def replace_d(s):
     return s
 
 
-def function_type_from_am(shell_am, base_type, spherical_type):
-    if max(shell_am) <= 1:
-        return base_type
-    else:
-        return base_type + '_' + spherical_type
-
-
 def potential_am_list(max_am):
     '''Creates a canonical list of AM for use with ECP potentials
 
@@ -96,25 +89,6 @@ def remove_expected_line(lines, expected='', position=0):
     new_lines = lines[:]
     new_lines.pop(position)
     return new_lines
-
-
-def create_element_data(bs_data, element_Z, key, key_exist_ok=False, element_exist_ok=True, create=list):
-    '''Creates an element and a subkey of the element in bs_data
-
-    Note that bs_data is modified!
-    '''
-
-    if element_Z not in bs_data:
-        bs_data[element_Z] = {}
-    elif not element_exist_ok:
-        raise RuntimeError("Element {} already exists in basis data".format(element_Z))
-
-    if key not in bs_data[element_Z]:
-        bs_data[element_Z][key] = create()
-    elif not key_exist_ok:
-        raise RuntimeError("Key {} already exists in basis data for element {}".format(key, element_Z))
-
-    return bs_data[element_Z]
 
 
 def parse_line_regex(rex, line, description=None, convert_int=True):

--- a/basis_set_exchange/readers/molcas.py
+++ b/basis_set_exchange/readers/molcas.py
@@ -1,5 +1,5 @@
 import re
-from .. import lut, misc
+from .. import lut, manip, misc
 from . import helpers
 
 element_head_re = re.compile(r'^/([a-zA-Z]{1,3})\.(?:ECP\.)?([^.]+)\..*$')
@@ -14,7 +14,7 @@ ecp_pot_begin_re = re.compile(r'^(\d+)\s*;.*$')  # Sometime comments are after t
 
 
 def _parse_electron_lines(basis_lines, bs_data, element_Z):
-    element_data = helpers.create_element_data(bs_data, element_Z, 'electron_shells')
+    element_data = manip.create_element_data(bs_data, element_Z, 'electron_shells')
 
     # Handle the options block
     # This specifies the kind of data that might be found at the end of the element block
@@ -98,7 +98,7 @@ def _parse_electron_lines(basis_lines, bs_data, element_Z):
         coefficients = misc.transpose_matrix(coefficients)
 
         # Now add to the bs_data
-        func_type = helpers.function_type_from_am([shell_am], 'gto', 'spherical')
+        func_type = lut.function_type_from_am([shell_am], 'gto', 'spherical')
 
         shell = {
             'function_type': func_type,
@@ -125,7 +125,7 @@ def _parse_ecp_lines(basis_lines, bs_data, element_Z):
     if element_Z_ecp != element_Z:
         raise RuntimeError("ECP element Z={} found in block for element Z={}".format(element_Z, element_Z_ecp))
 
-    element_data = helpers.create_element_data(bs_data, element_Z, 'ecp_potentials')
+    element_data = manip.create_element_data(bs_data, element_Z, 'ecp_potentials')
 
     # Does the ecp_electrons key exist? This may have been determined when reading the
     # electron shells above

--- a/basis_set_exchange/readers/nwchem.py
+++ b/basis_set_exchange/readers/nwchem.py
@@ -1,5 +1,5 @@
 import re
-from .. import lut
+from .. import lut, manip
 from . import helpers
 
 am_line_re = re.compile(r'^([A-Za-z]+)\s+([A-Za-z]+)$')
@@ -31,9 +31,9 @@ def _parse_electron_lines(basis_lines, bs_data):
         shell_am = lut.amchar_to_int(shell_am)
 
         element_Z = lut.element_Z_from_sym(element_sym, as_str=True)
-        element_data = helpers.create_element_data(bs_data, element_Z, 'electron_shells', key_exist_ok=True)
+        element_data = manip.create_element_data(bs_data, element_Z, 'electron_shells', key_exist_ok=True)
 
-        func_type = helpers.function_type_from_am(shell_am, 'gto', am_type)
+        func_type = lut.function_type_from_am(shell_am, 'gto', am_type)
 
         # How many columns of coefficients do we have?
         # Only if this is a fused shell do we know
@@ -78,13 +78,13 @@ def _parse_ecp_lines(basis_lines, bs_data):
             element_sym, n_elec = helpers.parse_line_regex(nelec_re, pot_lines[0].lower(), "ECP: Element sym, nelec")
 
             element_Z = lut.element_Z_from_sym(element_sym, as_str=True)
-            element_data = helpers.create_element_data(bs_data, element_Z, 'ecp_electrons', create=int)
+            element_data = manip.create_element_data(bs_data, element_Z, 'ecp_electrons', create=int)
             element_data['ecp_electrons'] = n_elec
         else:
             element_sym, pot_am = helpers.parse_line_regex(am_line_re, pot_lines[0], "ECP: Element sym, pot AM")
 
             element_Z = lut.element_Z_from_sym(element_sym, as_str=True)
-            element_data = helpers.create_element_data(bs_data, element_Z, 'ecp_potentials', key_exist_ok=True)
+            element_data = manip.create_element_data(bs_data, element_Z, 'ecp_potentials', key_exist_ok=True)
 
             # See if this is the 'ul' angular momentum
             if pot_am.lower() == 'ul':

--- a/basis_set_exchange/readers/turbomole.py
+++ b/basis_set_exchange/readers/turbomole.py
@@ -1,5 +1,5 @@
 import re
-from .. import lut
+from .. import lut, manip
 from . import helpers
 
 section_re = re.compile(r'^\$(basis|ecp|cbas|jbas|jkbas)$')
@@ -41,7 +41,7 @@ def _parse_electron_lines(basis_lines, bs_data):
         element_sym, _ = helpers.parse_line_regex(element_re, element_lines[1], 'Element line')
 
         element_Z = lut.element_Z_from_sym(element_sym, as_str=True)
-        element_data = helpers.create_element_data(bs_data, element_Z, 'electron_shells')
+        element_data = manip.create_element_data(bs_data, element_Z, 'electron_shells')
 
         # Partition into shells
         shell_blocks = helpers.partition_lines(element_lines[3:], shell_re.match, min_size=2)
@@ -50,7 +50,7 @@ def _parse_electron_lines(basis_lines, bs_data):
             nprim, shell_am = helpers.parse_line_regex(shell_re, sh_lines[0], 'shell nprim, am')
             shell_am = lut.amchar_to_int(shell_am)
 
-            func_type = helpers.function_type_from_am(shell_am, 'gto', 'spherical')
+            func_type = lut.function_type_from_am(shell_am, 'gto', 'spherical')
 
             exponents, coefficients = helpers.parse_primitive_matrix(sh_lines[1:], nprim=nprim, ngen=1)
 
@@ -75,12 +75,12 @@ def _parse_ecp_potential_lines(element_lines, bs_data):
     element_Z = lut.element_Z_from_sym(element_sym, as_str=True)
 
     # We don't need the return value - we will use the one from creating ecp_electrons
-    helpers.create_element_data(bs_data, element_Z, 'ecp_potentials')
+    manip.create_element_data(bs_data, element_Z, 'ecp_potentials')
 
     # 4th line should be ncore and lmax
     n_elec, max_am = helpers.parse_line_regex(ecp_info_re, element_lines[1], 'ECP ncore, lmax')
 
-    element_data = helpers.create_element_data(bs_data, element_Z, 'ecp_electrons', key_exist_ok=False, create=int)
+    element_data = manip.create_element_data(bs_data, element_Z, 'ecp_electrons', key_exist_ok=False, create=int)
     element_data['ecp_electrons'] = n_elec
 
     # split the remaining lines by lines starting with a character


### PR DESCRIPTION
AutoAux, a method for generation of general-use auxiliary basis sets, has been described in [J. Chem. Theory Comput. 13, 554 (2017)](https://doi.org/10.1021/acs.jctc.6b01041). I've verified with help from Frank Neese and Georgi Stoychev that this implementation reproduces ORCA for the cc-pwCVQZ basis set at least for B, C, N, and O, and doing so found three typos in the paper.

auto-ABS, a method for Coulomb-fitting auxiliary basis sets, has been described in [J. Chem. Phys. 127, 074102 (2007)](https://doi.org/10.1063/1.2752807). This scheme is much sim
