### PR TITLE
Add Gaussian system library format output

### DIFF
--- a/basis_set_exchange/writers/g94.py
+++ b/basis_set_exchange/writers/g94.py
@@ -5,7 +5,7 @@ Conversion of basis sets to Gaussian format
 from .. import lut, manip, sort, printing
 
 
-def _write_g94_common(basis, add_harm_type, psi4_am):
+def _write_g94_common(basis, add_harm_type, psi4_am, system_library):
     '''Converts a basis set to Gaussian format
     '''
 
@@ -27,7 +27,7 @@ def _write_g94_common(basis, add_harm_type, psi4_am):
             data = basis['elements'][z]
 
             sym = lut.element_sym_from_Z(z, True)
-            s += '{}     0\n'.format(sym)
+            s += '{}{}     0\n'.format('-' if system_library else '', sym)
 
             for shell in data['electron_shells']:
                 exponents = shell['exponents']
@@ -93,7 +93,13 @@ def _write_g94_common(basis, add_harm_type, psi4_am):
 def write_g94(basis):
     '''Converts a basis set to Gaussian format
     '''
-    return _write_g94_common(basis, False, False)
+    return _write_g94_common(basis, False, False, False)
+
+
+def write_g94lib(basis):
+    '''Converts a basis set to Gaussian system library format
+    '''
+    return _write_g94_common(basis, False, False, True)
 
 
 def write_xtron(basis):
@@ -102,7 +108,7 @@ def write_xtron(basis):
     xTron uses a modified gaussian format that puts 'c' on the same
     line as the angular momentum if the shell is cartesian.
     '''
-    return _write_g94_common(basis, True, False)
+    return _write_g94_common(basis, True, False, False)
 
 
 def write_psi4(basis):
@@ -117,5 +123,5 @@ def write_psi4(basis):
     '''
 
     s = '****\n'
-    s += _write_g94_common(basis, False, True)
+    s += _write_g94_common(basis, False, True, False)
     return s

--- a/basis_set_exchange/writers/write.py
+++ b/basis_set_exchange/writers/write.py
@@ -5,7 +5,7 @@ Converts basis set data to a specified output format
 import bz2
 from .bsejson import write_json
 from .nwchem import write_nwchem
-from .g94 import write_g94, write_xtron, write_psi4
+from .g94 import write_g94, write_g94lib, write_xtron, write_psi4
 from .gamess_us import write_gamess_us
 from .gamess_uk import write_gamess_uk
 from .qchem import write_qchem
@@ -36,6 +36,13 @@ _writer_map = {
         'comment': '!',
         'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
         'function': write_g94
+    },
+    'gaussian94lib': {
+        'display': 'Gaussian, system library',
+        'extension': '.gbs',
+        'comment': '!',
+        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'function': write_g94lib
     },
     'psi4': {
         'display': 'Psi4',

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -70,7 +70,7 @@ and can be obtained via :func:`basis_set_exchange.get_formats`
 
    >>> # Available formats are available via get_formats
    >>> basis_set_exchange.get_formats()
-   {'nwchem': 'NWChem', 'gaussian94': 'Gaussian', 'psi4': 'Psi4',...
+   {'nwchem': 'NWChem', 'gaussian94': 'Gaussian', ...
 
 
 By default, all elements for which the basis set is defined are included. You can specify a 


### PR DESCRIPTION
The current Gaussian'94 format causes Gaussian to crash if the basis set has elements that are not included in the calculation.

This PR adds a new output format that adds the `-` sign in front of the element symbols, so that Gaussian runs smoothly even if you don't have some elements present.