### PR TITLE
Implement reader and interface for MolCAS RICDLib format

### DIFF
--- a/basis_set_exchange/readers/read.py
+++ b/basis_set_exchange/readers/read.py
@@ -15,6 +15,7 @@ from .dalton import read_dalton
 from .molcas import read_molcas
 from .genbas import read_genbas
 from .demon2k import read_demon2k
+from .ricdlib import read_ricdlib
 
 _reader_map = {
     'turbomole': {
@@ -61,6 +62,11 @@ _reader_map = {
         'display': 'deMon2k',
         'extension': '.d2k',
         'reader': read_demon2k
+    },
+    'ricdlib': {
+        'display': 'MolCAS RICDlib',
+        'extension': '.RICDLib',
+        'reader': read_ricdlib
     }
 }
 

--- a/basis_set_exchange/readers/ricdlib.py
+++ b/basis_set_exchange/readers/ricdlib.py
@@ -1,0 +1,101 @@
+'''
+Parser for OpenMolcas' RICDlib format
+
+Written by Susi Lehtola, 2021
+'''
+
+import re
+from .. import lut, misc
+from . import helpers
+
+# Start for new basis entry
+basis_head_re = re.compile(r'^/([a-zA-Z]+).({})....(aCD|acCD)-aux-basis.\s*$'.format(helpers.basis_name_re_str))
+# Elemental charge, lmax, number of basis set blocks
+charge_line_re = re.compile(r'^\s*({})\s+(\d+)\s+(\d+)\s*$'.format(helpers.floating_re_str))
+dummy_line_re = re.compile(r'^\s*Dummy reference line.\s*$')
+# nprim, ncontr, functype
+shell_start_re = re.compile('^\s*(\d+)\s+(\d+)\s+(\d+)\s*$')
+
+# Floating point data
+array_data_re = re.compile(r'^\s*(?:\s({}))+\s*$'.format(helpers.floating_re_str))
+
+
+def _parse_basis(basis_lines, bs_data):
+    # Parse symbol
+    element_symbol, basis_name, basis_type = helpers.parse_line_regex(basis_head_re, basis_lines[0],
+                                                                      'Symbol.Basis....a(c)CD-aux-basis.')
+
+    # Initialize BSE basis
+    element_Z = lut.element_Z_from_sym(element_symbol)
+    element_data = helpers.create_element_data(bs_data, str(element_Z), 'electron_shells')
+
+    # Read charge line (we don't care about the number of basis sets
+    # since we parse everything anyway)
+    charge, lmax, _ = helpers.parse_line_regex(charge_line_re, basis_lines[1], 'charge, lmax, foo')
+
+    # We should have two dummy lines
+    if not dummy_line_re.match(basis_lines[2]):
+        raise RuntimeError('Expected dummy line, got: "{}"!'.format(basis_lines[2]))
+    if not dummy_line_re.match(basis_lines[3]):
+        raise RuntimeError('Expected dummy line, got: "{}"!'.format(basis_lines[3]))
+
+    # Shell data
+    shell_data = basis_lines[4:]
+
+    # Parse the shells
+    for l in range(lmax + 1):
+        nprim, ncontr, amtype = helpers.parse_line_regex(shell_start_re, shell_data[0], 'charge, lmax, foo')
+        shell_data = shell_data[1:]
+        if nprim == 0 or ncontr == 0:
+            # Skip over dummy entries
+            continue
+
+        # Read the exponents
+        exponents, shell_data = helpers.read_n_floats(shell_data, nprim)
+
+        # Read the contraction coefficients
+        coefficients, shell_data = helpers.read_n_floats(shell_data, nprim * ncontr)
+        coefficients = helpers.chunk_list(coefficients, nprim, ncontr)
+        coefficients = misc.transpose_matrix(coefficients)
+
+        # Store the shell. It is cartesian, unless the amtype flag is
+        # 3 which means spherical transform and removal of the
+        # lower-angular-momentum contaminants.
+        func_type = helpers.function_type_from_am([l], 'gto', 'spherical' if amtype == 3 else 'cartesian')
+        shell = {
+            'function_type': func_type,
+            'region': '',
+            'angular_momentum': [l],
+            'exponents': exponents,
+            'coefficients': coefficients
+        }
+        element_data['electron_shells'].append(shell)
+
+
+def read_ricdlib(basis_lines):
+    '''Reads ricdlib-formatted file data and converts it to a dictionary with the
+       usual BSE fields
+
+       Note that the molcas format does not store all the fields we
+       have, so some fields are left blank
+    '''
+
+    bs_data = {}
+
+    # Split into elements
+    element_blocks = helpers.partition_lines(basis_lines, basis_head_re.match)
+
+    # Inside the loop, check that all blocks refer to the same basis set
+    basis_names_found = set()
+
+    for element_lines in element_blocks:
+        element_symbol, basis_name, basis_type = helpers.parse_line_regex(basis_head_re, element_lines[0],
+                                                                          'Symbol.Basis....a(c)CD-aux-basis.')
+        basis_names_found.add(basis_name.lower())
+        _parse_basis(element_lines, bs_data)
+
+    # Check for multiple basis sets
+    if len(basis_names_found) > 1:
+        raise RuntimeError("Multiple basis sets found in file: " + ','.join(basis_names_found))
+
+    return bs_data

--- a/basis_set_exchange/readers/ricdlib.py
+++ b/basis_set_exchange/readers/ricdlib.py
@@ -9,7 +9,7 @@ from .. import lut, misc
 from . import helpers
 
 # Start for new basis entry
-basis_head_re = re.compile(r'^/([a-zA-Z]+).({})....(aCD|acCD)-aux-basis.\s*$'.format(helpers.basis_name_re_str))
+basis_head_re = re.compile(r'^/([a-zA-Z]+).({}|)....(aCD|acCD)-aux-basis.\s*$'.format(helpers.basis_name_re_str))
 # Elemental charge, lmax, number of basis set blocks
 charge_line_re = re.compile(r'^\s*({})\s+(\d+)\s+(\d+)\s*$'.format(helpers.floating_re_str))
 dummy_line_re = re.compile(r'^\s*Dummy reference line.\s*$')
@@ -26,8 +26,11 @@ def _parse_basis(basis_lines, bs_data):
                                                                       'Symbol.Basis....a(c)CD-aux-basis.')
 
     # Initialize BSE basis
-    element_Z = lut.element_Z_from_sym(element_symbol)
-    element_data = helpers.create_element_data(bs_data, str(element_Z), 'electron_shells')
+    element_Z = str(lut.element_Z_from_sym(element_symbol))
+    if element_Z not in bs_data or 'electron_shells' not in bs_data[element_Z]:
+        element_data = helpers.create_element_data(bs_data, element_Z, 'electron_shells')
+    else:
+        element_data = bs_data[element_Z]
 
     # Read charge line (we don't care about the number of basis sets
     # since we parse everything anyway)

--- a/basis_set_exchange/writers/molcas.py
+++ b/basis_set_exchange/writers/molcas.py
@@ -19,15 +19,6 @@ def write_molcas(basis):
 
         has_electron = 'electron_shells' in data
         has_ecp = 'ecp_potentials' in data
-        if has_electron:
-            # Are there cartesian shells?
-            cartesian_shells = set()
-            for shell in data['electron_shells']:
-                if shell['function_type'] == 'gto_cartesian':
-                    for am in shell['angular_momentum']:
-                        cartesian_shells.add(lut.amint_to_char([am]))
-            if len(cartesian_shells):
-                s += 'Cartesian {}\n'.format(' '.join(cartesian_shells))
 
         el_name = lut.element_name_from_Z(z).upper()
         el_sym = lut.element_sym_from_Z(z, normalize=True)
@@ -47,6 +38,15 @@ def write_molcas(basis):
                 nelectrons -= data['ecp_electrons']
 
             s += '{:>7}.00   {}\n'.format(nelectrons, max_am)
+
+            # Are there cartesian shells?
+            cartesian_shells = set()
+            for shell in data['electron_shells']:
+                if shell['function_type'] == 'gto_cartesian':
+                    for am in shell['angular_momentum']:
+                        cartesian_shells.add(lut.amint_to_char([am]))
+            if len(cartesian_shells):
+                s += 'cartesian {}\n'.format(' '.join(cartesian_shells))
 
             for shell in data['electron_shells']:
                 exponents = shell['exponents']

--- a/basis_set_exchange/writers/molcas.py
+++ b/basis_set_exchange/writers/molcas.py
@@ -16,8 +16,18 @@ def write_molcas(basis):
 
     for z, data in basis['elements'].items():
         s += 'Basis set\n'
+
         has_electron = 'electron_shells' in data
         has_ecp = 'ecp_potentials' in data
+        if has_electron:
+            # Are there cartesian shells?
+            cartesian_shells = set()
+            for shell in data['electron_shells']:
+                if shell['function_type'] == 'gto_cartesian':
+                    for am in shell['angular_momentum']:
+                        cartesian_shells.add(lut.amint_to_char([am]))
+            if len(cartesian_shells):
+                s += 'Cartesian {}\n'.format(' '.join(cartesian_shells))
 
         el_name = lut.element_name_from_Z(z).upper()
         el_sym = lut.element_sym_from_Z(z, normalize=True)

--- a/basis_set_exchange/writers/molcas.py
+++ b/basis_set_exchange/writers/molcas.py
@@ -39,15 +39,6 @@ def write_molcas(basis):
 
             s += '{:>7}.00   {}\n'.format(nelectrons, max_am)
 
-            # Are there cartesian shells?
-            cartesian_shells = set()
-            for shell in data['electron_shells']:
-                if shell['function_type'] == 'gto_cartesian':
-                    for am in shell['angular_momentum']:
-                        cartesian_shells.add(lut.amint_to_char([am]))
-            if len(cartesian_shells):
-                s += 'cartesian {}\n'.format(' '.join(cartesian_shells))
-
             for shell in data['electron_shells']:
                 exponents = shell['exponents']
                 coefficients = shell['coefficients']
@@ -92,6 +83,16 @@ def write_molcas(basis):
             s += 'Spectral\n'
             s += 'End of Spectral\n'
             s += '*\n'
+
+        if has_electron:
+            # Are there cartesian shells?
+            cartesian_shells = set()
+            for shell in data['electron_shells']:
+                if shell['function_type'] == 'gto_cartesian':
+                    for am in shell['angular_momentum']:
+                        cartesian_shells.add(lut.amint_to_char([am]))
+            if len(cartesian_shells):
+                s += 'cartesian {}\n'.format(' '.join(cartesian_shells))
 
         s += 'End of basis set\n\n'
 

--- a/basis_set_exchange/writers/ricdwrap.py
+++ b/basis_set_exchange/writers/ricdwrap.py
@@ -16,6 +16,7 @@ def write_ricdwrap(basis):
 &GATEWAY
   ricd
   accd
+  cdthreshold=1.0d-4
 '''
 
     for z, data in basis['elements'].items():

--- a/basis_set_exchange/writers/ricdwrap.py
+++ b/basis_set_exchange/writers/ricdwrap.py
@@ -38,15 +38,6 @@ def write_ricdwrap(basis):
 
             s += '{:>7}.00   {}\n'.format(nelectrons, max_am)
 
-            # Are there cartesian shells?
-            cartesian_shells = set()
-            for shell in data['electron_shells']:
-                if shell['function_type'] == 'gto_cartesian':
-                    for am in shell['angular_momentum']:
-                        cartesian_shells.add(lut.amint_to_char([am]))
-            if len(cartesian_shells):
-                s += 'cartesian {}\n'.format(' '.join(cartesian_shells))
-
             for shell in data['electron_shells']:
                 exponents = shell['exponents']
                 coefficients = shell['coefficients']
@@ -64,6 +55,16 @@ def write_ricdwrap(basis):
 
         # Make a nucleus; use 10 angstrom distance
         s += '{} 0.0 0.0 {:.1f}\n'.format(el_sym, 10.0 * (int(z) - 1))
+
+        # Are there cartesian shells?
+        if has_electron:
+            cartesian_shells = set()
+            for shell in data['electron_shells']:
+                if shell['function_type'] == 'gto_cartesian':
+                    for am in shell['angular_momentum']:
+                        cartesian_shells.add(lut.amint_to_char([am]))
+            if len(cartesian_shells):
+                s += 'cartesian {}\n'.format(' '.join(cartesian_shells))
 
         s += 'End of basis set\n\n'
 

--- a/basis_set_exchange/writers/ricdwrap.py
+++ b/basis_set_exchange/writers/ricdwrap.py
@@ -22,6 +22,15 @@ def write_ricdwrap(basis):
     for z, data in basis['elements'].items():
         s += 'Basis set\n'
         has_electron = 'electron_shells' in data
+        if has_electron:
+            # Are there cartesian shells?
+            cartesian_shells = set()
+            for shell in data['electron_shells']:
+                if shell['function_type'] == 'gto_cartesian':
+                    for am in shell['angular_momentum']:
+                        cartesian_shells.add(lut.amint_to_char([am]))
+            if len(cartesian_shells):
+                s += 'Cartesian {}\n'.format(' '.join(cartesian_shells))
 
         el_name = lut.element_name_from_Z(z).upper()
         el_sym = lut.element_sym_from_Z(z, normalize=True)

--- a/basis_set_exchange/writers/ricdwrap.py
+++ b/basis_set_exchange/writers/ricdwrap.py
@@ -22,15 +22,6 @@ def write_ricdwrap(basis):
     for z, data in basis['elements'].items():
         s += 'Basis set\n'
         has_electron = 'electron_shells' in data
-        if has_electron:
-            # Are there cartesian shells?
-            cartesian_shells = set()
-            for shell in data['electron_shells']:
-                if shell['function_type'] == 'gto_cartesian':
-                    for am in shell['angular_momentum']:
-                        cartesian_shells.add(lut.amint_to_char([am]))
-            if len(cartesian_shells):
-                s += 'Cartesian {}\n'.format(' '.join(cartesian_shells))
 
         el_name = lut.element_name_from_Z(z).upper()
         el_sym = lut.element_sym_from_Z(z, normalize=True)
@@ -46,6 +37,15 @@ def write_ricdwrap(basis):
             nelectrons = int(z)
 
             s += '{:>7}.00   {}\n'.format(nelectrons, max_am)
+
+            # Are there cartesian shells?
+            cartesian_shells = set()
+            for shell in data['electron_shells']:
+                if shell['function_type'] == 'gto_cartesian':
+                    for am in shell['angular_momentum']:
+                        cartesian_shells.add(lut.amint_to_char([am]))
+            if len(cartesian_shells):
+                s += 'cartesian {}\n'.format(' '.join(cartesian_shells))
 
             for shell in data['electron_shells']:
                 exponents = shell['exponents']

--- a/basis_set_exchange/writers/write.py
+++ b/basis_set_exchange/writers/write.py
@@ -174,7 +174,7 @@ _writer_map = {
     'ricdwrap': {
         'display': 'Wrapper for generating acCD auxiliary basis sets with OpenMolcas',
         'extension': '.ricdwrap',
-        'comment': '',
+        'comment': '*',
         'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
         'function': write_ricdwrap
     }

--- a/basis_set_exchange/writers/write.py
+++ b/basis_set_exchange/writers/write.py
@@ -21,6 +21,7 @@ from .pqs import write_pqs
 from .cp2k import write_cp2k
 from .bsedebug import write_bsedebug
 from .bdf import write_bdf
+from .ricdwrap import write_ricdwrap
 
 _writer_map = {
     'nwchem': {
@@ -169,6 +170,13 @@ _writer_map = {
         'comment': '*',
         'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
         'function': write_bdf
+    },
+    'ricdwrap': {
+        'display': 'Wrapper for generating acCD auxiliary basis sets with OpenMolcas',
+        'extension': '.ricdwrap',
+        'comment': '',
+        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'function': write_ricdwrap
     }
 }
 


### PR DESCRIPTION
This PR implements a reader for the RICDLib format used in OpenMolcas for storing automatically generated Cholesky auxiliary basis sets.

I've also included an output format i.e. writer to generate suitable input for OpenMolcas to generate the RICDLib file (wrapricd).

To use the code, one just has to
1. `bse get-basis ... ricdwrap > basis.input` to generate the OpenMolcas input
2. run OpenMolcas with `pymolcas basis.input` to generate the RICDLib file and
3. extract the acCD basis with `bse convert-basis basis.RICDLib ...`

Also fixes #218 i.e. the lack of discrimination between spherical and cartesian functions