### PR TITLE
WIP: Augmentation adds contracted exponents as free primitives

### DIFF
--- a/basis_set_exchange/api.py
+++ b/basis_set_exchange/api.py
@@ -100,8 +100,8 @@ def get_basis(name,
               remove_free_primitives=False,
               make_general=False,
               optimize_general=False,
-              augment_diffuse=0,
-              augment_steep=0,
+              augment_diffuse=-1,
+              augment_steep=-1,
               get_aux=0,
               data_dir=None,
               header=True):
@@ -260,13 +260,13 @@ def get_basis(name,
         basis_dict = manip.prune_basis(basis_dict, False)
 
     # Augment
-    if augment_diffuse > 0:
+    if augment_diffuse >= 0:
         basis_dict = manip.geometric_augmentation(basis_dict,
                                                   augment_diffuse,
                                                   use_copy=False,
                                                   as_component=False,
                                                   steep=False)
-    if augment_steep > 0:
+    if augment_steep >= 0:
         basis_dict = manip.geometric_augmentation(basis_dict,
                                                   augment_steep,
                                                   use_copy=False,
@@ -275,7 +275,7 @@ def get_basis(name,
         # Need to sort to get added steep functions first
         basis_dict = sort.sort_basis(basis_dict)
     # Re-make general
-    if (augment_diffuse > 0 or augment_steep > 0) and make_general:
+    if (augment_diffuse >= 0 or augment_steep >= 0) and make_general:
         basis_dict = manip.make_general(basis_dict, False, False)
 
     # Did we actually want an auxiliary basis set?

--- a/basis_set_exchange/cli/bse_cli.py
+++ b/basis_set_exchange/cli/bse_cli.py
@@ -102,8 +102,8 @@ def run_bse_cli():
     subp.add_argument('--rm-free', action='store_true', help='Remove free primitives')
     subp.add_argument('--opt-gen', action='store_true', help='Optimize general contractions')
     subp.add_argument('--make-gen', action='store_true', help='Make the basis set as generally-contracted as possible')
-    subp.add_argument('--aug-steep', type=int, default=0, help='Augment with n steep functions')
-    subp.add_argument('--aug-diffuse', type=int, default=0, help='Augment with n diffuse functions')
+    subp.add_argument('--aug-steep', type=int, default=-1, help='Augment with n steep functions')
+    subp.add_argument('--aug-diffuse', type=int, default=-1, help='Augment with n diffuse functions')
     subp.add_argument('--get-aux',
                       type=int,
                       default=0,

--- a/basis_set_exchange/manip.py
+++ b/basis_set_exchange/manip.py
@@ -555,7 +555,7 @@ def geometric_augmentation(basis, nadd, use_copy=True, as_component=False, steep
 
     '''
 
-    if nadd < 1:
+    if nadd < 0:
         raise RuntimeError("Adding {} functions makes no sense for geometric_augmentation".format(nadd))
 
     # We need to combine shells by AM
@@ -624,14 +624,23 @@ def geometric_augmentation(basis, nadd, use_copy=True, as_component=False, steep
                     "The two outermost exponents are the same. Duplicate exponents are not a good thing here. Exponent: {}"
                     .format(ref_exp))
 
-            # Test that the primitives for the references are free.
+            # Check if the primitives for the references are free.
+            def add_if_contracted(idx, expn):
+                if idx not in free_prims:
+                    # The primitive is contracted; we need to add it as a
+                    # free primitive to make sure we don't get extra
+                    # contraction error
+                    print('expn={} idx={} not in free prims, adding'.format(expn,idx))
+                    new_shells.append({
+                        'function_type': shell['function_type'],
+                        'region': shell['region'],
+                        'angular_momentum': shell['angular_momentum'],
+                        'exponents': [expn],
+                        'coefficients': [['1.00000000']]
+                    })
             free_prims = _free_primitives(shell['coefficients'])
-            if (ref_idx not in free_prims) or (next_idx not in free_prims):
-                # The shell does not have enough free primitives so
-                # skip the extrapolation. (The alternative would be to
-                # add in free primitives anyway, but then you'd have a
-                # problem with contraction errors.)
-                continue
+            add_if_contracted(ref_idx, ref_exp)
+            add_if_contracted(next_idx, next_exp)
 
             # Form new exponents
             new_exponents = []
@@ -639,7 +648,6 @@ def geometric_augmentation(basis, nadd, use_copy=True, as_component=False, steep
                 new_exponents.append(ref_exp * (beta**i))
 
             new_exponents = ['{:.6e}'.format(x) for x in new_exponents]
-
             # add the new exponents as new uncontracted shells
             for ex in new_exponents:
                 new_shells.append({


### PR DESCRIPTION
IIRC there are some basis sets where the most diffuse primitive is contracted. This PR changes the behavior of the `geometric_augmentation` function such that the steepest/most diffuse primitives are added into the basis when the number of functions to add is "zero".