### PR TITLE
Skip creating bundle files for incompatible basis set/writer combos

### DIFF
--- a/basis_set_exchange/bundle.py
+++ b/basis_set_exchange/bundle.py
@@ -9,6 +9,7 @@ import tarfile
 import io
 import datetime
 from . import api, writers, refconverters, misc
+from .writers.write import _writer_map
 
 _readme_str = '''Basis set exchange: Basis set bundle
 ==========================================
@@ -62,9 +63,16 @@ def _basis_data_iter(fmt, reffmt, data_dir):
     '''Iterate over all basis set names, and return a tuple of
        (name, data) where data is the basis set in the given format
     '''
+
+    ref_function_types = _writer_map[fmt]['valid']
+
     md = api.get_metadata(data_dir)
     for bs, bs_md in md.items():
         versions = bs_md['versions'].keys()
+
+        if not set(bs_md['function_types']) <= ref_function_types:
+            print("Skipping {}/{} because not all function types are supported".format(bs, fmt))
+            continue
 
         data = {}
         for v in versions:

--- a/basis_set_exchange/writers/write.py
+++ b/basis_set_exchange/writers/write.py
@@ -30,140 +30,140 @@ _writer_map = {
         'display': 'NWChem',
         'extension': '.nw',
         'comment': '#',
-        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'valid': {'gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp'},
         'function': write_nwchem
     },
     'gaussian94': {
         'display': 'Gaussian',
         'extension': '.gbs',
         'comment': '!',
-        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'valid': {'gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp'},
         'function': write_g94
     },
     'gaussian94lib': {
         'display': 'Gaussian, system library',
         'extension': '.gbs',
         'comment': '!',
-        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'valid': {'gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp'},
         'function': write_g94lib
     },
     'psi4': {
         'display': 'Psi4',
         'extension': '.gbs',
         'comment': '!',
-        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'valid': {'gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp'},
         'function': write_psi4
     },
     'molcas': {
         'display': 'Molcas',
         'extension': '.molcas',
         'comment': '*',
-        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'valid': {'gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp'},
         'function': write_molcas
     },
     'qchem': {
         'display': 'Q-Chem',
         'extension': '.qchem',
         'comment': '!',
-        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'valid': {'gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp'},
         'function': write_qchem
     },
     'orca': {
         'display': 'ORCA',
         'extension': '.orca',
         'comment': '!',
-        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'valid': {'gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp'},
         'function': write_orca
     },
     'dalton': {
         'display': 'Dalton',
         'extension': '.dalton',
         'comment': '!',
-        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'valid': {'gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp'},
         'function': write_dalton
     },
     'qcschema': {
         'display': 'QCSchema',
         'extension': '.json',
         'comment': None,
-        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'valid': {'gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp'},
         'function': write_qcschema
     },
     'cp2k': {
         'display': 'CP2K',
         'extension': '.cp2k',
         'comment': '#',
-        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'valid': {'gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp'},
         'function': write_cp2k
     },
     'pqs': {
         'display': 'PQS',
         'extension': '.pqs',
         'comment': '!',
-        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'valid': {'gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp'},
         'function': write_pqs
     },
     'demon2k': {
         'display': 'deMon2K',
         'extension': '.d2k',
         'comment': '#',
-        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'valid': {'gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp'},
         'function': write_demon2k
     },
     'gamess_us': {
         'display': 'GAMESS US',
         'extension': '.bas',
         'comment': '!',
-        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'valid': {'gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp'},
         'function': write_gamess_us
     },
     'turbomole': {
         'display': 'Turbomole',
         'extension': '.tm',
         'comment': '#',
-        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'valid': {'gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp'},
         'function': write_turbomole
     },
     'gamess_uk': {
         'display': 'GAMESS UK',
         'extension': '.bas',
         'comment': '#',
-        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'valid': {'gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp'},
         'function': write_gamess_uk
     },
     'molpro': {
         'display': 'Molpro',
         'extension': '.mpro',
         'comment': '!',
-        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'valid': {'gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp'},
         'function': write_molpro
     },
     'libmol': {
         'display': 'Molpro system library',
         'extension': '.libmol',
         'comment': '!',
-        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'valid': {'gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp'},
         'function': write_libmol
     },
     'cfour': {
         'display': 'CFOUR',
         'extension': '.c4bas',
         'comment': '!',
-        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'valid': {'gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp'},
         'function': write_cfour
     },
     'acesii': {
         'display': 'ACES II',
         'extension': '.acesii',
         'comment': '!',
-        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'valid': {'gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp'},
         'function': write_aces2
     },
     'xtron': {
         'display': 'xTron',
         'extension': '.gbs',
         'comment': '!',
-        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'valid': {'gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp'},
         'function': write_xtron
     },
     'bsedebug': {
@@ -184,21 +184,21 @@ _writer_map = {
         'display': 'BDF',
         'extension': '.bdf',
         'comment': '*',
-        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'valid': {'gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp'},
         'function': write_bdf
     },
     'ricdwrap': {
         'display': 'Wrapper for generating acCD auxiliary basis sets with OpenMolcas',
         'extension': '.ricdwrap',
         'comment': '*',
-        'valid': set(['gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp']),
+        'valid': {'gto', 'gto_cartesian', 'gto_spherical', 'scalar_ecp'},
         'function': write_ricdwrap
     },
     'fhiaims': {
         'display': 'FHI-aims',
         'extension': '.fhiaims',
         'comment': '#',
-        'valid': set(['gto', 'gto_cartesian', 'gto_spherical']),
+        'valid': {'gto', 'gto_cartesian', 'gto_spherical'},
         'function': write_fhiaims
     }
 }


### PR DESCRIPTION
When creating bundles, skip any basis sets for which a particular format does not support a function type

Ie, fhiaims and any basis set with ECP. But this is a general solution (I hope)