### PR TITLE
fix: importlib constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ if __name__ == "__main__":
         },
         install_requires=['jsonschema', 'argcomplete', 'regex'],
         extras_require={
-            ':python_version == "3.6"': ["importlib-metadata < 3"],
-            ':python_version == "3.7"': ["importlib-metadata < 3"],
+            ':python_version == "3.6"': ["importlib-metadata"],
+            ':python_version == "3.7"': ["importlib-metadata"],
             'docs': ['sphinx', 'sphinxcontrib-programoutput', 'sphinx_rtd_theme', 'graphviz'],
             'tests': [
                 # List pytest-cov before pytest because of a dumb pip bug


### PR DESCRIPTION
Relax restrictive constraint on importlib version that caused conflicts
with software in the Jupyter ecosystem.

P.S. You've configured CI to only run on pushes & pull requests to `master`.
When following a regular branching strategy, I believe this means that CI will not run on forks (?), which prevents contributors from checking whether CI passes before making a pull request.
Furthermore, with the new policies you'll now need to approve workflow runs manually.
I suggest you enable CI to run on any branch.

On my fork, I've now pushed to `master` in order to get the workflow to run