### PR TITLE
Add make-gen argument to convert-basis

### DIFF
--- a/basis_set_exchange/cli/bse_cli.py
+++ b/basis_set_exchange/cli/bse_cli.py
@@ -152,6 +152,7 @@ def run_bse_cli():
     subp.add_argument(
         '--out-fmt', type=str, default=None,
         help='Output format (default: autodetected from output filename').completer = cli_write_fmt_completer
+    subp.add_argument('--make-gen', action='store_true', help='Make the basis set as generally-contracted as possible')
 
     #################################
     # Auxiliary basis sets

--- a/basis_set_exchange/cli/bse_handlers.py
+++ b/basis_set_exchange/cli/bse_handlers.py
@@ -196,7 +196,7 @@ def _bse_cli_convert_basis(args):
     '''Handles the convert-basis subcommand'''
 
     # We convert file -> file
-    convert.convert_formatted_basis_file(args.input_file, args.output_file, args.in_fmt, args.out_fmt)
+    convert.convert_formatted_basis_file(args.input_file, args.output_file, args.in_fmt, args.out_fmt, make_gen=args.make_gen)
     return "Converted {} -> {}".format(args.input_file, args.output_file)
 
 
@@ -204,14 +204,6 @@ def _bse_cli_create_bundle(args):
     '''Handles the create-bundle subcommand'''
     bundle.create_bundle(args.bundle_file, args.fmt, args.reffmt, args.archive_type, args.data_dir)
     return "Created " + args.bundle_file
-
-
-def _bse_cli_convert_basis(args):
-    '''Handles the convert-basis subcommand'''
-
-    # We convert file -> file
-    convert.convert_formatted_basis_file(args.input_file, args.output_file, args.in_fmt, args.out_fmt)
-    return "Converted {} -> {}".format(args.input_file, args.output_file)
 
 
 def _bse_cli_autoaux_basis(args):

--- a/basis_set_exchange/convert.py
+++ b/basis_set_exchange/convert.py
@@ -4,6 +4,7 @@ Functions for basis set conversion
 
 from .readers import read_formatted_basis_file, read_formatted_basis_str
 from .writers import write_formatted_basis_file, write_formatted_basis_str
+from .manip import make_general
 
 
 def convert_formatted_basis_str(basis_in, in_fmt, out_fmt):
@@ -28,7 +29,7 @@ def convert_formatted_basis_str(basis_in, in_fmt, out_fmt):
     return write_formatted_basis_str(basis_dict, out_fmt)
 
 
-def convert_formatted_basis_file(file_path_in, file_path_out, in_fmt=None, out_fmt=None, encoding='utf-8-sig'):
+def convert_formatted_basis_file(file_path_in, file_path_out, in_fmt=None, out_fmt=None, encoding='utf-8-sig', make_gen=False):
     '''Convert a formatted basis set file to another format
 
     Parameters
@@ -55,5 +56,7 @@ def convert_formatted_basis_file(file_path_in, file_path_out, in_fmt=None, out_f
                                            encoding=encoding,
                                            validate=True,
                                            as_component=False)
+    if make_gen:
+        basis_dict = make_general(basis_dict, use_copy=False)
 
     write_formatted_basis_file(basis_dict, file_path_out, basis_fmt=out_fmt)


### PR DESCRIPTION
When converting from a segmented contraction basis set format to a general contraction basis set format like NWChem, one needs to be able to run make_general in the conversion.