### PR TITLE
Adjust dalton ECP writing

### DIFF
--- a/basis_set_exchange/writers/dalton.py
+++ b/basis_set_exchange/writers/dalton.py
@@ -84,30 +84,21 @@ def write_dalton(basis):
         s += '\n\nECP\n'
         for z in ecp_elements:
             data = basis['elements'][z]
-            sym = lut.element_sym_from_Z(z, normalize=True)
             max_ecp_am = max([x['angular_momentum'][0] for x in data['ecp_potentials']])
-
             # Sort lowest->highest, then put the highest at the beginning
             ecp_list = sorted(data['ecp_potentials'], key=lambda x: x['angular_momentum'])
             ecp_list.insert(0, ecp_list.pop())
-
-            s += '{} nelec {}\n'.format(sym, data['ecp_electrons'])
-
+            s += 'a {:3d}\n$\n'.format(int(z))
+            s += '{:4d}{:4d}\n'.format(max_ecp_am, data['ecp_electrons'])
             for pot in ecp_list:
                 rexponents = pot['r_exponents']
                 gexponents = pot['gaussian_exponents']
                 coefficients = pot['coefficients']
-
-                am = pot['angular_momentum']
-                amchar = lut.amint_to_char(am).upper()
-
-                if am[0] == max_ecp_am:
-                    s += '{} ul\n'.format(sym)
-                else:
-                    s += '{} {}\n'.format(sym, amchar)
-
+                s += '{:12d}\n'.format(len(rexponents))
                 point_places = [0, 9, 32]
-                s += printing.write_matrix([rexponents, gexponents, *coefficients], point_places, convert_exp=False)
-
-        s += 'END\n'
+                s += printing.write_matrix([rexponents, gexponents, *coefficients],
+                                           point_places,
+                                           convert_exp=False)
+            s += '$\n'
+        s += '$ END OF ECP\n'
     return s


### PR DESCRIPTION
This PR adjusts ECP writing to the Dalton format.
An example of the format is:
```
$
a  37
$
   3  28
           1
 2      3.843114000000    -12.316900000000
           3
 2      5.036551000000     89.500198000000
 2      1.970849000000      0.493761000000
 2      3.843114000000     12.316900000000
           3
 2      4.258341000000     58.568974000000
 2      1.470709000000      0.431791000000
 2      3.843114000000     12.316900000000
           3
 2      3.023127000000     26.224898000000
 2      0.650383000000      0.962839000000
 2      3.843114000000     12.316900000000
$
```
A full file is available here: https://gitlab.com/dalton/dalton/-/raw/30e11f9d007e39fc617d5fc37806cba08dcfb277/basis/ecp_data/def2_svp?inline=true 





Note that Dalton keeps regular basis sets and basis sets in different files (`basis` and `basis/ecp_data`).