### PR TITLE
ANO basis set references were missing the subtitles

### DIFF
--- a/basis_set_exchange/data/REFERENCES.json
+++ b/basis_set_exchange/data/REFERENCES.json
@@ -66,7 +66,7 @@
       "Widmark, Per-Olof",
       "Roos, Björn O."
     ],
-    "title": "Density matrix averaged atomic natural orbital (ANO) basis sets for correlated molecular wave functions",
+    "title": "Density matrix averaged atomic natural orbital (ANO) basis sets for correlated molecular wave functions. III. First row transition metal atoms",
     "journal": "Theor. Chim. Acta",
     "volume": "92",
     "pages": "149",
@@ -5241,7 +5241,7 @@
       "Malmqvist, Per-Åke",
       "Roos, Björn O."
     ],
-    "title": "Density matrix averaged atomic natural orbital (ANO) basis sets for correlated molecular wave functions",
+    "title": "Density matrix averaged atomic natural orbital (ANO) basis sets for correlated molecular wave functions. I. First row atoms",
     "journal": "Theor. Chim. Acta",
     "volume": "77",
     "pages": "291-306",
@@ -5255,7 +5255,7 @@
       "Persson, B. Joakim",
       "Roos, Björn O."
     ],
-    "title": "Density matrix averaged atomic natural orbital (ANO) basis sets for correlated molecular wave functions",
+    "title": "Density matrix averaged atomic natural orbital (ANO) basis sets for correlated molecular wave functions. II. Second row atoms",
     "journal": "Theor. Chim. Acta",
     "volume": "79",
     "pages": "419-432",


### PR DESCRIPTION
Many journals failed to include the subtitle in their automated DOI entries. This adds the missing subtitles to the ANO papers by Widmark and coworkers.