### PR TITLE
Implement even-tempered 8s8p8d protonic basis

### DIFF
--- a/basis_set_exchange/data/METADATA.json
+++ b/basis_set_exchange/data/METADATA.json
@@ -28153,6 +28153,32 @@
       }
     }
   },
+  "epc-8s8p8d": {
+    "display_name": "epc-8s8p8d",
+    "other_names": [],
+    "description": "Even-tempered 8s8p8d protonic basis",
+    "latest_version": "1",
+    "tags": [],
+    "basename": "epc-8s8p8d",
+    "relpath": "",
+    "family": "pb",
+    "role": "orbital",
+    "function_types": [
+      "gto",
+      "gto_spherical"
+    ],
+    "auxiliaries": {},
+    "versions": {
+      "1": {
+        "file_relpath": "epc-8s8p8d.1.table.json",
+        "revdesc": "Data from article",
+        "revdate": "2024-01-23",
+        "elements": [
+          "1"
+        ]
+      }
+    }
+  },
   "fano-5z": {
     "display_name": "FANO-5Z",
     "other_names": [],

--- a/basis_set_exchange/data/REFERENCES.json
+++ b/basis_set_exchange/data/REFERENCES.json
@@ -5365,6 +5365,22 @@
     "year": "2005",
     "doi": "10.1007/s00214-005-0629-0"
   },
+  "yang2017a": {
+    "_entry_type": "article",
+    "authors": [
+      "Yang, Yang",
+      "Brorsen, Kurt R.",
+      "Culpitt, Tanner",
+      "Pak, Michael V.",
+      "Hammes-Schiffer, Sharon"
+    ],
+    "title": "Development of a practical multicomponent density functional for electron-proton correlation to produce accurate proton densities",
+    "journal": "J. Chem. Phys.",
+    "volume": "147",
+    "pages": "114113",
+    "year": "2017",
+    "doi": "10.1063/1.4996038"
+  },
   "yockel2008a": {
     "_entry_type": "article",
     "authors": [

--- a/basis_set_exchange/data/epc-8s8p8d.1.table.json
+++ b/basis_set_exchange/data/epc-8s8p8d.1.table.json
@@ -1,0 +1,11 @@
+{
+  "molssi_bse_schema": {
+    "schema_type": "table",
+    "schema_version": "0.1"
+  },
+  "revision_description": "Data from article",
+  "revision_date": "2024-01-23",
+  "elements": {
+    "1": "pb/epc-8s8p8d.1.element.json"
+  }
+}

--- a/basis_set_exchange/data/epc-8s8p8d.metadata.json
+++ b/basis_set_exchange/data/epc-8s8p8d.metadata.json
@@ -1,0 +1,14 @@
+{
+  "molssi_bse_schema": {
+    "schema_type": "metadata",
+    "schema_version": "0.1"
+  },
+  "names": [
+    "epc-8s8p8d"
+  ],
+  "tags": [],
+  "family": "pb",
+  "description": "Even-tempered 8s8p8d protonic basis",
+  "role": "orbital",
+  "auxiliaries": {}
+}

--- a/basis_set_exchange/data/pb/epc-8s8p8d.1.element.json
+++ b/basis_set_exchange/data/pb/epc-8s8p8d.1.element.json
@@ -1,0 +1,15 @@
+{
+  "molssi_bse_schema": {
+    "schema_type": "element",
+    "schema_version": "0.1"
+  },
+  "name": "epc-8s8p8d",
+  "description": "Even-tempered 8s8p8d protonic basis",
+  "elements": {
+    "1": {
+      "components": [
+        "pb/epc-8s8p8d.1.json"
+      ]
+    }
+  }
+}

--- a/basis_set_exchange/data/pb/epc-8s8p8d.1.json
+++ b/basis_set_exchange/data/pb/epc-8s8p8d.1.json
@@ -1,0 +1,377 @@
+{
+  "molssi_bse_schema": {
+    "schema_type": "component",
+    "schema_version": "0.1"
+  },
+  "description": "Even-tempered 8s8p8d protonic basis",
+  "data_source": "Data from article",
+  "elements": {
+    "1": {
+      "references": [
+        "yang2017a"
+      ],
+      "electron_shells": [
+        {
+          "function_type": "gto",
+          "region": "",
+          "angular_momentum": [
+            0
+          ],
+          "exponents": [
+            "2.8284271247461903"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto",
+          "region": "",
+          "angular_momentum": [
+            0
+          ],
+          "exponents": [
+            "4.0"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto",
+          "region": "",
+          "angular_momentum": [
+            0
+          ],
+          "exponents": [
+            "5.65685424949238"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto",
+          "region": "",
+          "angular_momentum": [
+            0
+          ],
+          "exponents": [
+            "8.0"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto",
+          "region": "",
+          "angular_momentum": [
+            0
+          ],
+          "exponents": [
+            "11.31370849898476"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto",
+          "region": "",
+          "angular_momentum": [
+            0
+          ],
+          "exponents": [
+            "16.0"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto",
+          "region": "",
+          "angular_momentum": [
+            0
+          ],
+          "exponents": [
+            "22.62741699796952"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto",
+          "region": "",
+          "angular_momentum": [
+            0
+          ],
+          "exponents": [
+            "32.0"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto",
+          "region": "",
+          "angular_momentum": [
+            1
+          ],
+          "exponents": [
+            "2.8284271247461903"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto",
+          "region": "",
+          "angular_momentum": [
+            1
+          ],
+          "exponents": [
+            "4.0"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto",
+          "region": "",
+          "angular_momentum": [
+            1
+          ],
+          "exponents": [
+            "5.65685424949238"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto",
+          "region": "",
+          "angular_momentum": [
+            1
+          ],
+          "exponents": [
+            "8.0"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto",
+          "region": "",
+          "angular_momentum": [
+            1
+          ],
+          "exponents": [
+            "11.31370849898476"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto",
+          "region": "",
+          "angular_momentum": [
+            1
+          ],
+          "exponents": [
+            "16.0"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto",
+          "region": "",
+          "angular_momentum": [
+            1
+          ],
+          "exponents": [
+            "22.62741699796952"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto",
+          "region": "",
+          "angular_momentum": [
+            1
+          ],
+          "exponents": [
+            "32.0"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_spherical",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "2.8284271247461903"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_spherical",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "4.0"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_spherical",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "5.65685424949238"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_spherical",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "8.0"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_spherical",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "11.31370849898476"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_spherical",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "16.0"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_spherical",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "22.62741699796952"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_spherical",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "32.0"
+          ],
+          "coefficients": [
+            [
+              "1.0"
+            ]
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Implements even-tempered 8s8p8d protonic orbital basis set from [J. Chem. Phys. 147, 114113 (2017)](https://doi.org/10.1063/1.4996038)