### PR TITLE
Fix descriptions of sigma basis sets

### DIFF
--- a/basis_set_exchange/data/METADATA.json
+++ b/basis_set_exchange/data/METADATA.json
@@ -7424,7 +7424,7 @@
   "asigmadz": {
     "display_name": "asigmaDZ",
     "other_names": [],
-    "description": "{} basis",
+    "description": "asigmaDZ basis",
     "latest_version": "1",
     "tags": [],
     "basename": "asigmaDZ",
@@ -7440,7 +7440,7 @@
       "1": {
         "file_relpath": "asigmaDZ.1.table.json",
         "revdesc": "Data from supporting information",
-        "revdate": "2023-07-02",
+        "revdate": "2024-01-12",
         "elements": [
           "1",
           "2",
@@ -7459,7 +7459,7 @@
   "asigmaqz": {
     "display_name": "asigmaQZ",
     "other_names": [],
-    "description": "{} basis",
+    "description": "asigmaQZ basis",
     "latest_version": "1",
     "tags": [],
     "basename": "asigmaQZ",
@@ -7475,7 +7475,7 @@
       "1": {
         "file_relpath": "asigmaQZ.1.table.json",
         "revdesc": "Data from supporting information",
-        "revdate": "2023-07-02",
+        "revdate": "2024-01-12",
         "elements": [
           "1",
           "2",
@@ -7494,7 +7494,7 @@
   "asigmatz": {
     "display_name": "asigmaTZ",
     "other_names": [],
-    "description": "{} basis",
+    "description": "asigmaTZ basis",
     "latest_version": "1",
     "tags": [],
     "basename": "asigmaTZ",
@@ -7510,7 +7510,7 @@
       "1": {
         "file_relpath": "asigmaTZ.1.table.json",
         "revdesc": "Data from supporting information",
-        "revdate": "2023-07-02",
+        "revdate": "2024-01-12",
         "elements": [
           "1",
           "2",
@@ -41495,7 +41495,7 @@
   "sigmadz": {
     "display_name": "sigmaDZ",
     "other_names": [],
-    "description": "{} basis",
+    "description": "sigmaDZ basis",
     "latest_version": "1",
     "tags": [],
     "basename": "sigmaDZ",
@@ -41511,7 +41511,7 @@
       "1": {
         "file_relpath": "sigmaDZ.1.table.json",
         "revdesc": "Data from supporting information",
-        "revdate": "2023-07-02",
+        "revdate": "2024-01-12",
         "elements": [
           "1",
           "2",
@@ -41530,7 +41530,7 @@
   "sigmadzhf": {
     "display_name": "sigmaDZHF",
     "other_names": [],
-    "description": "{} basis for Hellmann-Feynman forces",
+    "description": "sigmaDZHF basis for Hellmann-Feynman forces",
     "latest_version": "1",
     "tags": [],
     "basename": "sigmaDZHF",
@@ -41546,7 +41546,7 @@
       "1": {
         "file_relpath": "sigmaDZHF.1.table.json",
         "revdesc": "Data from Susi Lehtola",
-        "revdate": "2022-12-15",
+        "revdate": "2024-01-12",
         "elements": [
           "1",
           "6",
@@ -41563,7 +41563,7 @@
   "sigmaqz": {
     "display_name": "sigmaQZ",
     "other_names": [],
-    "description": "{} basis",
+    "description": "sigmaQZ basis",
     "latest_version": "1",
     "tags": [],
     "basename": "sigmaQZ",
@@ -41579,7 +41579,7 @@
       "1": {
         "file_relpath": "sigmaQZ.1.table.json",
         "revdesc": "Data from supporting information",
-        "revdate": "2023-07-02",
+        "revdate": "2024-01-12",
         "elements": [
           "1",
           "2",
@@ -41598,7 +41598,7 @@
   "sigmaszhf": {
     "display_name": "sigmaSZHF",
     "other_names": [],
-    "description": "{} basis for Hellmann-Feynman forces",
+    "description": "sigmaSZHF basis for Hellmann-Feynman forces",
     "latest_version": "1",
     "tags": [],
     "basename": "sigmaSZHF",
@@ -41614,7 +41614,7 @@
       "1": {
         "file_relpath": "sigmaSZHF.1.table.json",
         "revdesc": "Data from Susi Lehtola",
-        "revdate": "2022-12-15",
+        "revdate": "2024-01-12",
         "elements": [
           "1",
           "6",
@@ -41631,7 +41631,7 @@
   "sigmatz": {
     "display_name": "sigmaTZ",
     "other_names": [],
-    "description": "{} basis",
+    "description": "sigmaTZ basis",
     "latest_version": "1",
     "tags": [],
     "basename": "sigmaTZ",
@@ -41647,7 +41647,7 @@
       "1": {
         "file_relpath": "sigmaTZ.1.table.json",
         "revdesc": "Data from supporting information",
-        "revdate": "2023-07-02",
+        "revdate": "2024-01-12",
         "elements": [
           "1",
           "2",
@@ -41666,7 +41666,7 @@
   "sigmatzhf": {
     "display_name": "sigmaTZHF",
     "other_names": [],
-    "description": "{} basis for Hellmann-Feynman forces",
+    "description": "sigmaTZHF basis for Hellmann-Feynman forces",
     "latest_version": "1",
     "tags": [],
     "basename": "sigmaTZHF",
@@ -41682,7 +41682,7 @@
       "1": {
         "file_relpath": "sigmaTZHF.1.table.json",
         "revdesc": "Data from Susi Lehtola",
-        "revdate": "2022-12-15",
+        "revdate": "2024-01-12",
         "elements": [
           "1",
           "6",

--- a/basis_set_exchange/data/asigmaDZ.1.table.json
+++ b/basis_set_exchange/data/asigmaDZ.1.table.json
@@ -4,7 +4,7 @@
     "schema_version": "0.1"
   },
   "revision_description": "Data from supporting information",
-  "revision_date": "2023-07-02",
+  "revision_date": "2024-01-12",
   "elements": {
     "1": "sigmaNZ/asigmaDZ.1.element.json",
     "2": "sigmaNZ/asigmaDZ.1.element.json",

--- a/basis_set_exchange/data/asigmaDZ.metadata.json
+++ b/basis_set_exchange/data/asigmaDZ.metadata.json
@@ -8,7 +8,7 @@
   ],
   "tags": [],
   "family": "sigmanz",
-  "description": "{} basis",
+  "description": "asigmaDZ basis",
   "role": "orbital",
   "auxiliaries": {}
 }

--- a/basis_set_exchange/data/asigmaQZ.1.table.json
+++ b/basis_set_exchange/data/asigmaQZ.1.table.json
@@ -4,7 +4,7 @@
     "schema_version": "0.1"
   },
   "revision_description": "Data from supporting information",
-  "revision_date": "2023-07-02",
+  "revision_date": "2024-01-12",
   "elements": {
     "1": "sigmaNZ/asigmaQZ.1.element.json",
     "2": "sigmaNZ/asigmaQZ.1.element.json",

--- a/basis_set_exchange/data/asigmaQZ.metadata.json
+++ b/basis_set_exchange/data/asigmaQZ.metadata.json
@@ -8,7 +8,7 @@
   ],
   "tags": [],
   "family": "sigmanz",
-  "description": "{} basis",
+  "description": "asigmaQZ basis",
   "role": "orbital",
   "auxiliaries": {}
 }

--- a/basis_set_exchange/data/asigmaTZ.1.table.json
+++ b/basis_set_exchange/data/asigmaTZ.1.table.json
@@ -4,7 +4,7 @@
     "schema_version": "0.1"
   },
   "revision_description": "Data from supporting information",
-  "revision_date": "2023-07-02",
+  "revision_date": "2024-01-12",
   "elements": {
     "1": "sigmaNZ/asigmaTZ.1.element.json",
     "2": "sigmaNZ/asigmaTZ.1.element.json",

--- a/basis_set_exchange/data/asigmaTZ.metadata.json
+++ b/basis_set_exchange/data/asigmaTZ.metadata.json
@@ -8,7 +8,7 @@
   ],
   "tags": [],
   "family": "sigmanz",
-  "description": "{} basis",
+  "description": "asigmaTZ basis",
   "role": "orbital",
   "auxiliaries": {}
 }

--- a/basis_set_exchange/data/sigmaDZ.1.table.json
+++ b/basis_set_exchange/data/sigmaDZ.1.table.json
@@ -4,7 +4,7 @@
     "schema_version": "0.1"
   },
   "revision_description": "Data from supporting information",
-  "revision_date": "2023-07-02",
+  "revision_date": "2024-01-12",
   "elements": {
     "1": "sigmaNZ/sigmaDZ.1.element.json",
     "2": "sigmaNZ/sigmaDZ.1.element.json",

--- a/basis_set_exchange/data/sigmaDZ.metadata.json
+++ b/basis_set_exchange/data/sigmaDZ.metadata.json
@@ -8,7 +8,7 @@
   ],
   "tags": [],
   "family": "sigmanz",
-  "description": "{} basis",
+  "description": "sigmaDZ basis",
   "role": "orbital",
   "auxiliaries": {}
 }

--- a/basis_set_exchange/data/sigmaDZHF.1.table.json
+++ b/basis_set_exchange/data/sigmaDZHF.1.table.json
@@ -4,7 +4,7 @@
     "schema_version": "0.1"
   },
   "revision_description": "Data from Susi Lehtola",
-  "revision_date": "2022-12-15",
+  "revision_date": "2024-01-12",
   "elements": {
     "1": "sigmaNZ/sigmaDZHF.1.element.json",
     "6": "sigmaNZ/sigmaDZHF.1.element.json",

--- a/basis_set_exchange/data/sigmaDZHF.metadata.json
+++ b/basis_set_exchange/data/sigmaDZHF.metadata.json
@@ -8,7 +8,7 @@
   ],
   "tags": [],
   "family": "sigmanz",
-  "description": "{} basis for Hellmann-Feynman forces",
+  "description": "sigmaDZHF basis for Hellmann-Feynman forces",
   "role": "orbital",
   "auxiliaries": {}
 }

--- a/basis_set_exchange/data/sigmaNZ/asigmaDZ.1.element.json
+++ b/basis_set_exchange/data/sigmaNZ/asigmaDZ.1.element.json
@@ -4,7 +4,7 @@
     "schema_version": "0.1"
   },
   "name": "asigmaDZ",
-  "description": "{} basis",
+  "description": "asigmaDZ basis",
   "elements": {
     "1": {
       "components": [

--- a/basis_set_exchange/data/sigmaNZ/asigmaDZ.1.json
+++ b/basis_set_exchange/data/sigmaNZ/asigmaDZ.1.json
@@ -3,7 +3,7 @@
     "schema_type": "component",
     "schema_version": "0.1"
   },
-  "description": "{} basis",
+  "description": "asigmaDZ basis",
   "data_source": "Data from supporting information",
   "elements": {
     "1": {

--- a/basis_set_exchange/data/sigmaNZ/asigmaQZ.1.element.json
+++ b/basis_set_exchange/data/sigmaNZ/asigmaQZ.1.element.json
@@ -4,7 +4,7 @@
     "schema_version": "0.1"
   },
   "name": "asigmaQZ",
-  "description": "{} basis",
+  "description": "asigmaQZ basis",
   "elements": {
     "1": {
       "components": [

--- a/basis_set_exchange/data/sigmaNZ/asigmaQZ.1.json
+++ b/basis_set_exchange/data/sigmaNZ/asigmaQZ.1.json
@@ -3,7 +3,7 @@
     "schema_type": "component",
     "schema_version": "0.1"
   },
-  "description": "{} basis",
+  "description": "asigmaQZ basis",
   "data_source": "Data from supporting information",
   "elements": {
     "1": {

--- a/basis_set_exchange/data/sigmaNZ/asigmaTZ.1.element.json
+++ b/basis_set_exchange/data/sigmaNZ/asigmaTZ.1.element.json
@@ -4,7 +4,7 @@
     "schema_version": "0.1"
   },
   "name": "asigmaTZ",
-  "description": "{} basis",
+  "description": "asigmaTZ basis",
   "elements": {
     "1": {
       "components": [

--- a/basis_set_exchange/data/sigmaNZ/asigmaTZ.1.json
+++ b/basis_set_exchange/data/sigmaNZ/asigmaTZ.1.json
@@ -3,7 +3,7 @@
     "schema_type": "component",
     "schema_version": "0.1"
   },
-  "description": "{} basis",
+  "description": "asigmaTZ basis",
   "data_source": "Data from supporting information",
   "elements": {
     "1": {

--- a/basis_set_exchange/data/sigmaNZ/sigmaDZ.1.element.json
+++ b/basis_set_exchange/data/sigmaNZ/sigmaDZ.1.element.json
@@ -4,7 +4,7 @@
     "schema_version": "0.1"
   },
   "name": "sigmaDZ",
-  "description": "{} basis",
+  "description": "sigmaDZ basis",
   "elements": {
     "1": {
       "components": [

--- a/basis_set_exchange/data/sigmaNZ/sigmaDZ.1.json
+++ b/basis_set_exchange/data/sigmaNZ/sigmaDZ.1.json
@@ -3,7 +3,7 @@
     "schema_type": "component",
     "schema_version": "0.1"
   },
-  "description": "{} basis",
+  "description": "sigmaDZ basis",
   "data_source": "Data from supporting information",
   "elements": {
     "1": {

--- a/basis_set_exchange/data/sigmaNZ/sigmaDZHF.1.element.json
+++ b/basis_set_exchange/data/sigmaNZ/sigmaDZHF.1.element.json
@@ -4,7 +4,7 @@
     "schema_version": "0.1"
   },
   "name": "sigmaDZHF",
-  "description": "{} basis for Hellmann-Feynman forces",
+  "description": "sigmaDZHF basis for Hellmann-Feynman forces",
   "elements": {
     "1": {
       "components": [

--- a/basis_set_exchange/data/sigmaNZ/sigmaDZHF.1.json
+++ b/basis_set_exchange/data/sigmaNZ/sigmaDZHF.1.json
@@ -3,7 +3,7 @@
     "schema_type": "component",
     "schema_version": "0.1"
   },
-  "description": "{} basis for Hellmann-Feynman forces",
+  "description": "sigmaDZHF basis for Hellmann-Feynman forces",
   "data_source": "Data from Susi Lehtola",
   "elements": {
     "1": {

--- a/basis_set_exchange/data/sigmaNZ/sigmaQZ.1.element.json
+++ b/basis_set_exchange/data/sigmaNZ/sigmaQZ.1.element.json
@@ -4,7 +4,7 @@
     "schema_version": "0.1"
   },
   "name": "sigmaQZ",
-  "description": "{} basis",
+  "description": "sigmaQZ basis",
   "elements": {
     "1": {
       "components": [

--- a/basis_set_exchange/data/sigmaNZ/sigmaQZ.1.json
+++ b/basis_set_exchange/data/sigmaNZ/sigmaQZ.1.json
@@ -3,7 +3,7 @@
     "schema_type": "component",
     "schema_version": "0.1"
   },
-  "description": "{} basis",
+  "description": "sigmaQZ basis",
   "data_source": "Data from supporting information",
   "elements": {
     "1": {

--- a/basis_set_exchange/data/sigmaNZ/sigmaSZHF.1.element.json
+++ b/basis_set_exchange/data/sigmaNZ/sigmaSZHF.1.element.json
@@ -4,7 +4,7 @@
     "schema_version": "0.1"
   },
   "name": "sigmaSZHF",
-  "description": "{} basis for Hellmann-Feynman forces",
+  "description": "sigmaSZHF basis for Hellmann-Feynman forces",
   "elements": {
     "1": {
       "components": [

--- a/basis_set_exchange/data/sigmaNZ/sigmaSZHF.1.json
+++ b/basis_set_exchange/data/sigmaNZ/sigmaSZHF.1.json
@@ -3,7 +3,7 @@
     "schema_type": "component",
     "schema_version": "0.1"
   },
-  "description": "{} basis for Hellmann-Feynman forces",
+  "description": "sigmaSZHF basis for Hellmann-Feynman forces",
   "data_source": "Data from Susi Lehtola",
   "elements": {
     "1": {

--- a/basis_set_exchange/data/sigmaNZ/sigmaTZ.1.element.json
+++ b/basis_set_exchange/data/sigmaNZ/sigmaTZ.1.element.json
@@ -4,7 +4,7 @@
     "schema_version": "0.1"
   },
   "name": "sigmaTZ",
-  "description": "{} basis",
+  "description": "sigmaTZ basis",
   "elements": {
     "1": {
       "components": [

--- a/basis_set_exchange/data/sigmaNZ/sigmaTZ.1.json
+++ b/basis_set_exchange/data/sigmaNZ/sigmaTZ.1.json
@@ -3,7 +3,7 @@
     "schema_type": "component",
     "schema_version": "0.1"
   },
-  "description": "{} basis",
+  "description": "sigmaTZ basis",
   "data_source": "Data from supporting information",
   "elements": {
     "1": {

--- a/basis_set_exchange/data/sigmaNZ/sigmaTZHF.1.element.json
+++ b/basis_set_exchange/data/sigmaNZ/sigmaTZHF.1.element.json
@@ -4,7 +4,7 @@
     "schema_version": "0.1"
   },
   "name": "sigmaTZHF",
-  "description": "{} basis for Hellmann-Feynman forces",
+  "description": "sigmaTZHF basis for Hellmann-Feynman forces",
   "elements": {
     "1": {
       "components": [

--- a/basis_set_exchange/data/sigmaNZ/sigmaTZHF.1.json
+++ b/basis_set_exchange/data/sigmaNZ/sigmaTZHF.1.json
@@ -3,7 +3,7 @@
     "schema_type": "component",
     "schema_version": "0.1"
   },
-  "description": "{} basis for Hellmann-Feynman forces",
+  "description": "sigmaTZHF basis for Hellmann-Feynman forces",
   "data_source": "Data from Susi Lehtola",
   "elements": {
     "1": {

--- a/basis_set_exchange/data/sigmaQZ.1.table.json
+++ b/basis_set_exchange/data/sigmaQZ.1.table.json
@@ -4,7 +4,7 @@
     "schema_version": "0.1"
   },
   "revision_description": "Data from supporting information",
-  "revision_date": "2023-07-02",
+  "revision_date": "2024-01-12",
   "elements": {
     "1": "sigmaNZ/sigmaQZ.1.element.json",
     "2": "sigmaNZ/sigmaQZ.1.element.json",

--- a/basis_set_exchange/data/sigmaQZ.metadata.json
+++ b/basis_set_exchange/data/sigmaQZ.metadata.json
@@ -8,7 +8,7 @@
   ],
   "tags": [],
   "family": "sigmanz",
-  "description": "{} basis",
+  "description": "sigmaQZ basis",
   "role": "orbital",
   "auxiliaries": {}
 }

--- a/basis_set_exchange/data/sigmaSZHF.1.table.json
+++ b/basis_set_exchange/data/sigmaSZHF.1.table.json
@@ -4,7 +4,7 @@
     "schema_version": "0.1"
   },
   "revision_description": "Data from Susi Lehtola",
-  "revision_date": "2022-12-15",
+  "revision_date": "2024-01-12",
   "elements": {
     "1": "sigmaNZ/sigmaSZHF.1.element.json",
     "6": "sigmaNZ/sigmaSZHF.1.element.json",

--- a/basis_set_exchange/data/sigmaSZHF.metadata.json
+++ b/basis_set_exchange/data/sigmaSZHF.metadata.json
@@ -8,7 +8,7 @@
   ],
   "tags": [],
   "family": "sigmanz",
-  "description": "{} basis for Hellmann-Feynman forces",
+  "description": "sigmaSZHF basis for Hellmann-Feynman forces",
   "role": "orbital",
   "auxiliaries": {}
 }

--- a/basis_set_exchange/data/sigmaTZ.1.table.json
+++ b/basis_set_exchange/data/sigmaTZ.1.table.json
@@ -4,7 +4,7 @@
     "schema_version": "0.1"
   },
   "revision_description": "Data from supporting information",
-  "revision_date": "2023-07-02",
+  "revision_date": "2024-01-12",
   "elements": {
     "1": "sigmaNZ/sigmaTZ.1.element.json",
     "2": "sigmaNZ/sigmaTZ.1.element.json",

--- a/basis_set_exchange/data/sigmaTZ.metadata.json
+++ b/basis_set_exchange/data/sigmaTZ.metadata.json
@@ -8,7 +8,7 @@
   ],
   "tags": [],
   "family": "sigmanz",
-  "description": "{} basis",
+  "description": "sigmaTZ basis",
   "role": "orbital",
   "auxiliaries": {}
 }

--- a/basis_set_exchange/data/sigmaTZHF.1.table.json
+++ b/basis_set_exchange/data/sigmaTZHF.1.table.json
@@ -4,7 +4,7 @@
     "schema_version": "0.1"
   },
   "revision_description": "Data from Susi Lehtola",
-  "revision_date": "2022-12-15",
+  "revision_date": "2024-01-12",
   "elements": {
     "1": "sigmaNZ/sigmaTZHF.1.element.json",
     "6": "sigmaNZ/sigmaTZHF.1.element.json",

--- a/basis_set_exchange/data/sigmaTZHF.metadata.json
+++ b/basis_set_exchange/data/sigmaTZHF.metadata.json
@@ -8,7 +8,7 @@
   ],
   "tags": [],
   "family": "sigmanz",
-  "description": "{} basis for Hellmann-Feynman forces",
+  "description": "sigmaTZHF basis for Hellmann-Feynman forces",
   "role": "orbital",
   "auxiliaries": {}
 }


### PR DESCRIPTION
There was an unexpanded macro in the sigma basis set addition, which resulted in descriptions being `{}`. This PR fixes the descriptions of the sigma basis sets.