### PR TITLE
Upgrade versions in GHAs

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           fetch-depth: 0 # needed for tag/version
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -19,7 +19,6 @@ jobs:
           python-version: "3.10"
 
       - name: Install package
-        shell: bash -l {0}
         run: |
           python -m pip install .[docs]
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,13 +27,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,13 +50,11 @@ jobs:
 
       - name: Run tests
         working-directory: ./test_wdir # Move to an unrelated dir and test the installed package
-        shell: bash -l {0}
         run: |
           pytest --pyargs basis_set_exchange 
 
       - name: Test CLI
         working-directory: ./test_wdir # Move to an unrelated dir and test the installed package
-        shell: bash -l {0}
         run: |
           bse get-basis 6-31g nwchem
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Upgrades the versions of various github actions (setup-python and CodeQL). Hopefully, this will fix some of the errors on macos runners.

Removing the `shell` from the workflow seems to have fixed it. It doesn't seem to be required, and it seems part of the bug causing failing tests: https://github.com/actions/setup-python/issues/942