### PR TITLE
Fix author order in roos2004a reference.

### DIFF
--- a/basis_set_exchange/data/REFERENCES.json
+++ b/basis_set_exchange/data/REFERENCES.json
@@ -4380,9 +4380,9 @@
   "roos2004a": {
     "_entry_type": "article",
     "authors": [
+      "Roos, Björn O.",
       "Veryazov, Valera",
-      "Widmark, Per-Olof",
-      "Roos, Björn O."
+      "Widmark, Per-Olof"
     ],
     "title": "Relativistic atomic natural orbital type basis sets for the alkaline and alkaline-earth atoms applied to the ground-state potentials for the corresponding dimers",
     "journal": "Theor. Chem. Acc.",


### PR DESCRIPTION
The author order was incorrect compared to the actual paper, [doi:10.1007/s00214-003-0537-0](https://doi.org/10.1007/s00214-003-0537-0).