### PR TITLE
Fix deprecation warnings

### DIFF
--- a/basis_set_exchange/tests/conftest.py
+++ b/basis_set_exchange/tests/conftest.py
@@ -45,8 +45,8 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_slow)
 
 
-def pytest_ignore_collect(path, config):
+def pytest_ignore_collect(collection_path, config):
     if config.getoption("--runslow"):
         return False
     else:
-        return str(path).endswith('_slow.py')
+        return str(collection_path).endswith('_slow.py')


### PR DESCRIPTION
Goal is to fix two deprecation warnings:

- [X] Pytest warns about an old `path` option in `conftest.py` - replace with `collection_path`
- [ ] References are handled differently in `jsonschema` when doing validation - we must switch to the `referencing` package (which jsonschema already depends on)