### PR TITLE
Fix 6-31G(2df,p)

### DIFF
--- a/basis_set_exchange/data/6-31G(2df,p).1.table.json
+++ b/basis_set_exchange/data/6-31G(2df,p).1.table.json
@@ -1,0 +1,28 @@
+{
+  "molssi_bse_schema": {
+    "schema_type": "table",
+    "schema_version": "0.1"
+  },
+  "revision_description": "Fix of the original Basis Set Exchange data",
+  "revision_date": "2025-04-28",
+  "elements": {
+    "1": "pople/bse_v0/31GSS-H-BSE.0.element.json",
+    "2": "pople/bse_v0/31GSS.0.element.json",
+    "3": "pople/6-31G(2df).1.element.json",
+    "4": "pople/6-31G(2df).1.element.json",
+    "5": "pople/6-31G(2df).1.element.json",
+    "6": "pople/6-31G(2df).1.element.json",
+    "7": "pople/6-31G(2df).1.element.json",
+    "8": "pople/6-31G(2df).1.element.json",
+    "9": "pople/6-31G(2df).1.element.json",
+    "10": "pople/6-31G(2df).1.element.json",
+    "11": "pople/6-31G(2df).1.element.json",
+    "12": "pople/6-31G(2df).1.element.json",
+    "13": "pople/6-31G(2df).1.element.json",
+    "14": "pople/6-31G(2df).1.element.json",
+    "15": "pople/6-31G(2df).1.element.json",
+    "16": "pople/6-31G(2df).1.element.json",
+    "17": "pople/6-31G(2df).1.element.json",
+    "18": "pople/6-31G(2df).1.element.json"
+  }
+}

--- a/basis_set_exchange/data/METADATA.json
+++ b/basis_set_exchange/data/METADATA.json
@@ -2333,7 +2333,7 @@
     "display_name": "6-31G(2df,p)",
     "other_names": [],
     "description": "6-31G(2df,p)",
-    "latest_version": "0",
+    "latest_version": "1",
     "tags": [],
     "basename": "6-31G(2df,p)",
     "relpath": "",
@@ -2341,6 +2341,7 @@
     "role": "orbital",
     "function_types": [
       "gto",
+      "gto_cartesian",
       "gto_spherical"
     ],
     "auxiliaries": {},
@@ -2349,6 +2350,31 @@
         "file_relpath": "6-31G(2df,p).0.table.json",
         "revdesc": "Data from the original Basis Set Exchange",
         "revdate": "2016-07-11",
+        "elements": [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+          "6",
+          "7",
+          "8",
+          "9",
+          "10",
+          "11",
+          "12",
+          "13",
+          "14",
+          "15",
+          "16",
+          "17",
+          "18"
+        ]
+      },
+      "1": {
+        "file_relpath": "6-31G(2df,p).1.table.json",
+        "revdesc": "Fix of the original Basis Set Exchange data",
+        "revdate": "2025-04-28",
         "elements": [
           "1",
           "2",

--- a/basis_set_exchange/data/pople/6-31G(2df).1.element.json
+++ b/basis_set_exchange/data/pople/6-31G(2df).1.element.json
@@ -1,0 +1,130 @@
+{
+  "molssi_bse_schema": {
+    "schema_type": "element",
+    "schema_version": "0.1"
+  },
+  "name": "6-31G(2df,p)",
+  "description": "6-31G(2df,p)",
+  "elements": {
+    "3": {
+      "components": [
+        "pople/bse_v0/6-31G.0.json",
+        "pople/6-31G/6-31G-2d-polarization.1.json",
+        "pople/bse_v0/6-311G-f-polarization.0.json"
+      ]
+    },
+    "4": {
+      "components": [
+        "pople/bse_v0/6-31G.0.json",
+        "pople/6-31G/6-31G-2d-polarization.1.json",
+        "pople/bse_v0/6-311G-f-polarization.0.json"
+      ]
+    },
+    "5": {
+      "components": [
+        "pople/bse_v0/6-31G.0.json",
+        "pople/6-31G/6-31G-2d-polarization.1.json",
+        "pople/bse_v0/6-311G-f-polarization.0.json"
+      ]
+    },
+    "6": {
+      "components": [
+        "pople/bse_v0/6-31G.0.json",
+        "pople/6-31G/6-31G-2d-polarization.1.json",
+        "pople/bse_v0/6-311G-f-polarization.0.json"
+      ]
+    },
+    "7": {
+      "components": [
+        "pople/bse_v0/6-31G.0.json",
+        "pople/6-31G/6-31G-2d-polarization.1.json",
+        "pople/bse_v0/6-311G-f-polarization.0.json"
+      ]
+    },
+    "8": {
+      "components": [
+        "pople/bse_v0/6-31G.0.json",
+        "pople/6-31G/6-31G-2d-polarization.1.json",
+        "pople/bse_v0/6-311G-f-polarization.0.json"
+      ]
+    },
+    "9": {
+      "components": [
+        "pople/bse_v0/6-31G.0.json",
+        "pople/6-31G/6-31G-2d-polarization.1.json",
+        "pople/bse_v0/6-311G-f-polarization.0.json"
+      ]
+    },
+    "10": {
+      "components": [
+        "pople/bse_v0/6-31G.0.json",
+        "pople/6-31G/6-31G-2d-polarization.1.json",
+        "pople/bse_v0/6-311G-f-polarization.0.json"
+      ]
+    },
+    "11": {
+      "components": [
+        "pople/bse_v0/6-21G-core.0.json",
+        "pople/bse_v0/6-31G-valence.0.json",
+        "pople/6-31G/6-31G-2d-polarization.1.json",
+        "pople/bse_v0/6-311G-f-polarization.0.json"
+      ]
+    },
+    "12": {
+      "components": [
+        "pople/bse_v0/6-21G-core.0.json",
+        "pople/bse_v0/6-31G-valence.0.json",
+        "pople/6-31G/6-31G-2d-polarization.1.json",
+        "pople/bse_v0/6-311G-f-polarization.0.json"
+      ]
+    },
+    "13": {
+      "components": [
+        "pople/bse_v0/6-21G-core.0.json",
+        "pople/bse_v0/6-31G-valence.0.json",
+        "pople/6-31G/6-31G-2d-polarization.1.json",
+        "pople/bse_v0/6-311G-f-polarization.0.json"
+      ]
+    },
+    "14": {
+      "components": [
+        "pople/bse_v0/6-21G-core.0.json",
+        "pople/bse_v0/6-31G-valence.0.json",
+        "pople/6-31G/6-31G-2d-polarization.1.json",
+        "pople/bse_v0/6-311G-f-polarization.0.json"
+      ]
+    },
+    "15": {
+      "components": [
+        "pople/bse_v0/6-21G-core.0.json",
+        "pople/bse_v0/6-31G-valence.0.json",
+        "pople/6-31G/6-31G-2d-polarization.1.json",
+        "pople/bse_v0/6-311G-f-polarization.0.json"
+      ]
+    },
+    "16": {
+      "components": [
+        "pople/bse_v0/6-21G-core.0.json",
+        "pople/bse_v0/6-31G-valence.0.json",
+        "pople/6-31G/6-31G-2d-polarization.1.json",
+        "pople/bse_v0/6-311G-f-polarization.0.json"
+      ]
+    },
+    "17": {
+      "components": [
+        "pople/bse_v0/6-21G-core.0.json",
+        "pople/bse_v0/6-31G-valence.0.json",
+        "pople/6-31G/6-31G-2d-polarization.1.json",
+        "pople/bse_v0/6-311G-f-polarization.0.json"
+      ]
+    },
+    "18": {
+      "components": [
+        "pople/bse_v0/6-21G-core.0.json",
+        "pople/bse_v0/6-31G-valence.0.json",
+        "pople/6-31G/6-31G-2d-polarization.1.json",
+        "pople/bse_v0/6-311G-f-polarization.0.json"
+      ]
+    }
+  }
+}

--- a/basis_set_exchange/data/pople/6-31G/6-31G-2d-polarization.1.json
+++ b/basis_set_exchange/data/pople/6-31G/6-31G-2d-polarization.1.json
@@ -1,0 +1,602 @@
+{
+  "molssi_bse_schema": {
+    "schema_type": "component",
+    "schema_version": "0.1"
+  },
+  "description": "6-31G(2df)",
+  "data_source": "Original Basis Set Exchange",
+  "elements": {
+    "3": {
+      "references": [
+        "hariharan1973a"
+      ],
+      "electron_shells": [
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "0.4000000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "0.1000000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        }
+      ]
+    },
+    "4": {
+      "references": [
+        "hariharan1973a"
+      ],
+      "electron_shells": [
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "0.8000000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "0.2000000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        }
+      ]
+    },
+    "5": {
+      "references": [
+        "hariharan1973a"
+      ],
+      "electron_shells": [
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "1.2000000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "0.3000000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        }
+      ]
+    },
+    "6": {
+      "references": [
+        "hariharan1973a"
+      ],
+      "electron_shells": [
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "1.6000000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "0.4000000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        }
+      ]
+    },
+    "7": {
+      "references": [
+        "hariharan1973a"
+      ],
+      "electron_shells": [
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "1.6000000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "0.4000000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        }
+      ]
+    },
+    "8": {
+      "references": [
+        "hariharan1973a"
+      ],
+      "electron_shells": [
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "1.6000000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "0.4000000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        }
+      ]
+    },
+    "9": {
+      "references": [
+        "hariharan1973a"
+      ],
+      "electron_shells": [
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "1.6000000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "0.4000000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        }
+      ]
+    },
+    "10": {
+      "references": [
+        "hariharan1973a"
+      ],
+      "electron_shells": [
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "1.6000000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "0.4000000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        }
+      ]
+    },
+    "11": {
+      "references": [
+        "francl1982a"
+      ],
+      "electron_shells": [
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "0.3500000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "0.0875000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        }
+      ]
+    },
+    "12": {
+      "references": [
+        "francl1982a"
+      ],
+      "electron_shells": [
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "0.3500000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "0.0875000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        }
+      ]
+    },
+    "13": {
+      "references": [
+        "francl1982a"
+      ],
+      "electron_shells": [
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "0.6500000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "0.1625000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        }
+      ]
+    },
+    "14": {
+      "references": [
+        "francl1982a"
+      ],
+      "electron_shells": [
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "0.9000000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "0.2250000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        }
+      ]
+    },
+    "15": {
+      "references": [
+        "francl1982a"
+      ],
+      "electron_shells": [
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "1.1000000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "0.2750000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        }
+      ]
+    },
+    "16": {
+      "references": [
+        "francl1982a"
+      ],
+      "electron_shells": [
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "1.3000000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "0.3250000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        }
+      ]
+    },
+    "17": {
+      "references": [
+        "francl1982a"
+      ],
+      "electron_shells": [
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "1.5000000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "0.3750000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        }
+      ]
+    },
+    "18": {
+      "references": [
+        "francl1982a"
+      ],
+      "electron_shells": [
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "1.7000000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        },
+        {
+          "function_type": "gto_cartesian",
+          "region": "",
+          "angular_momentum": [
+            2
+          ],
+          "exponents": [
+            "0.4250000"
+          ],
+          "coefficients": [
+            [
+              "1.0000000"
+            ]
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR addresses issue #330.

The implemented changes are:
- Defined a new version of the data set in `6-31G(2df,p).1.table.json` and added that to `METADATA.json`
- Switch to `bse_v0/31GSS` (from `bse_v0/31G(2p)`) for `H` and `He` to fix the additional p-function on hydrogen.
- Added `pople/6-31G/6-31G-2d-polarization` to implement the correct exponents for the 2d functions (derived from `Hariharan1973a`) and set the `function_type` to `gto_cartesian` (which is one of the differences between 6-31G(2df,p) and 6-311G(2df,p) mentioned in `Frisch1984a`)
