### PR TITLE
Veloxchem writer should not change the basis unlike other writers

### DIFF
--- a/basis_set_exchange/writers/veloxchem.py
+++ b/basis_set_exchange/writers/veloxchem.py
@@ -42,13 +42,9 @@ def write_veloxchem(basis):
 
     s = f'@BASIS_SET {basis["name"]}\n'
 
-    basis = manip.optimize_general(basis, False)
-
     basis = manip.uncontract_general(basis, False)
-
     basis = manip.uncontract_spdf(basis, 0, False)
-
-    basis = manip.prune_basis(basis, False)
+    basis = sort.sort_basis(basis, False)
 
     # Elements for which we have electron basis
     electron_elements = [k for k, v in basis['elements'].items() if 'electron_shells' in v]


### PR DESCRIPTION
The Veloxchem writer was optimizing general contractions, which is not something it should do.

I also restored the sort which done in the other writers; the VeloxChem developers confirmed the program does not assume an order for the basis functions - which is how programs should always take in basis sets...

Closes #347