### PR TITLE
Update GHA actions and python versions

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
         
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # needed for tag/version
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Install package
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,15 +21,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Clone the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install package
         run: |
@@ -39,7 +39,7 @@ jobs:
                           # (testing installed BSE, not the source tree)
 
       - name: Clone QCSchema HEAD
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: molssi/QCSchema
           path: deps/QCSchema


### PR DESCRIPTION
Just some maintenance to keep up with GHA versions. Also enables python 3.14 and drops 3.8