### PR TITLE
Enable getting version via basis_set_exchange.version()

### DIFF
--- a/basis_set_exchange/__init__.py
+++ b/basis_set_exchange/__init__.py
@@ -54,8 +54,11 @@ from .validator import validate_file, validate_data
 
 from .bundle import create_bundle, get_archive_types
 
-from importlib.metadata import version
-__version__ = version("basis_set_exchange")
+from importlib.metadata import version as _version
+__version__ = _version("basis_set_exchange")
 
 def get_version():
+    return __version__
+
+def version():
     return __version__

--- a/basis_set_exchange/api.py
+++ b/basis_set_exchange/api.py
@@ -52,10 +52,11 @@ from . import sort
 from . import misc
 from . import lut
 
+# for backwards compatibility
 def version():
     '''Obtain the version of the basis set exchange library (as a string)'''
-    from . import __version__
-    return __version__
+    from . import version
+    return version()
 
 
 # Determine the path to the data directory that is part


### PR DESCRIPTION
A few times I've tried to do the generally-recognized standard

```
import basis_set_exchange as bse
bse.version()
```

However, that version function corresponds to the importlib version function, which requires the distribution name.

This fixes that so any of the following will work

```
import basis_set_exchange as bse
bse.version()
bse.get_version()
bse.api.version()
```

with the `bse.get_version` and `bse.api.version()` staying purely for backwards compatibility