### PR TITLE
Fix missing '-' prefix for ECP element header in gaussian94lib format

### DIFF
--- a/basis_set_exchange/writers/g94.py
+++ b/basis_set_exchange/writers/g94.py
@@ -95,7 +95,7 @@ def _write_g94_common(basis, add_harm_type, psi4_am, system_library):
             ecp_list = sorted(data['ecp_potentials'], key=lambda x: x['angular_momentum'])
             ecp_list.insert(0, ecp_list.pop())
 
-            s += '{}     0\n'.format(sym)
+            s += '{}{}     0\n'.format('-' if system_library else '', sym)
             s += '{}-ECP     {}     {}\n'.format(sym, max_ecp_am, data['ecp_electrons'])
 
             for pot in ecp_list:


### PR DESCRIPTION
Fixes #338

## Root cause

`_write_g94_common()` correctly adds a `-` prefix for orbital element headers when `system_library=True` (line 59):
```python
s += '{}{}     0\n'.format('-' if system_library else '', sym)  # line 59
```
But the ECP element header (line 97) uses a simpler form without this check:
```python
s += '{}     0\n'.format(sym)  # line 97 — missing '-' for system_library
```

## Fix

Apply the same prefix logic as line 59:
```python
s += '{}{}     0\n'.format('-' if system_library else '', sym)
```

## Verification

```python
import basis_set_exchange as bse
out = bse.get_basis('aug-cc-pVTZ-PP', elements=['Br'], fmt='gaussian94lib')
# Before fix: 'BR     0' (no dash in ECP element header)
# After fix:  '-BR     0' (consistent with '-Br     0' in orbital section)
```

## Impact

Any ECP-containing basis set exported in `gaussian94lib` format has the wrong element header in the ECP block. Basis sets without ECPs are unaffected. The `gaussian94` (non-lib) format is unaffected.