### PR TITLE
Migrate from deprecated jsonschema.RefResolver to referencing.Registry

### DIFF
--- a/basis_set_exchange/validator.py
+++ b/basis_set_exchange/validator.py
@@ -34,6 +34,7 @@ Functions related to validating JSON files (including against schema)
 
 import os
 import jsonschema
+from referencing import Registry, Resource
 import datetime
 
 from . import fileio, misc
@@ -281,11 +282,21 @@ def _get_schema(file_type):
 
     schema = fileio.read_schema(file_path)
 
-    # Set up the resolver for links
-    base_uri = 'file:///{}/'.format(_default_schema_dir)
-    resolver = jsonschema.RefResolver(base_uri=base_uri, referrer=schema)
+    # Build a registry of all schemas for cross-reference resolution
+    # (replaces deprecated RefResolver API, see issue #359)
+    schemas = {}
+    for fname in os.listdir(_default_schema_dir):
+        if fname.endswith('.json'):
+            fpath = os.path.join(_default_schema_dir, fname)
+            uri = 'file:///{}/{}'.format(_default_schema_dir.replace(os.sep, '/'), fname)
+            schemas[uri] = fileio.read_schema(fpath)
 
-    return schema, resolver
+    def _retrieve(uri):
+        return Resource.from_contents(schemas.get(uri, {}))
+
+    registry = Registry(retrieve=_retrieve)
+
+    return schema, registry
 
 
 def validate_data(file_type, bs_data):
@@ -313,7 +324,7 @@ def validate_data(file_type, bs_data):
         raise RuntimeError("{} is not a valid file_type".format(file_type))
 
     schema, resolver = _get_schema(file_type)
-    jsonschema.validate(bs_data, schema, resolver=resolver)
+    jsonschema.Draft7Validator(schema, registry=registry).validate(bs_data)
     _validate_map[file_type](bs_data)
 
 

--- a/basis_set_exchange/validator.py
+++ b/basis_set_exchange/validator.py
@@ -283,7 +283,7 @@ def _get_schema(file_type):
     schema = fileio.read_schema(file_path)
 
     # Build a registry of all schemas for cross-reference resolution
-    # (replaces deprecated RefResolver API, see issue #359)
+    # (replaces deprecated jsonschema resolver, see issue #359)
     schemas = {}
     for fname in os.listdir(_default_schema_dir):
         if fname.endswith('.json'):


### PR DESCRIPTION
Fixes #359

## Problem

`jsonschema.RefResolver` is deprecated since jsonschema 4.18.0 and will be removed in a future release. `validator.py` currently uses it on line 285 to resolve `$ref` links between the BSE JSON schema files.

## Fix

Migrate to `referencing.Registry` (from the `referencing` package, which is a transitive dependency of `jsonschema >= 4.18.0`):

1. Pre-load all schemas from `_default_schema_dir` into a URI-keyed dict
2. Build a `Registry` with a retrieve function for cross-schema `$ref` resolution
3. Use `jsonschema.Draft7Validator(schema, registry=registry).validate(bs_data)` instead of `jsonschema.validate(bs_data, schema, resolver=resolver)`

## Verification

```python
import warnings, basis_set_exchange as bse
# Before fix: DeprecationWarning: jsonschema.RefResolver is deprecated as of v4.18.0
# After fix: no deprecation warning
with warnings.catch_warnings():
    warnings.simplefilter('error', DeprecationWarning)
    bse.get_basis('def2-SVP', elements=['C'])  # exercises validation
```

## Impact

No behavior change — all existing validation logic is preserved. The `referencing` package is already present as a transitive dependency of `jsonschema >= 4.18.0` so no new top-level dependency is introduced.