### PR TITLE
Add 6-31G(d) alias for 6-31G* for consistency with 6-31G** (fixes #188)

### DIFF
--- a/basis_set_exchange/data/6-31GS.metadata.json
+++ b/basis_set_exchange/data/6-31GS.metadata.json
@@ -1,14 +1,15 @@
 {
-  "molssi_bse_schema": {
-    "schema_type": "metadata",
-    "schema_version": "0.1"
-  },
-  "names": [
-    "6-31G*"
-  ],
-  "tags": [],
-  "family": "pople",
-  "description": "6-31G + polarization on heavy atoms",
-  "role": "orbital",
-  "auxiliaries": {}
+    "molssi_bse_schema": {
+        "schema_type": "metadata",
+        "schema_version": "0.1"
+    },
+    "names": [
+        "6-31G*",
+        "6-31G(d)"
+    ],
+    "tags": [],
+    "family": "pople",
+    "description": "6-31G + polarization on heavy atoms",
+    "role": "orbital",
+    "auxiliaries": {}
 }


### PR DESCRIPTION
Fixes #188

## Problem

`6-31G**` has two names in its metadata: `['6-31G**', '6-31G(d,p)']`, making both `bse.get_basis('6-31G**')` and `bse.get_basis('6-31G(d,p)')` work.

`6-31G*` only has `['6-31G*']` — `bse.get_basis('6-31G(d)')` fails with a lookup error.

## Fix

Add `'6-31G(d)'` to the `names` list in `6-31GS.metadata.json`, matching the pattern established by `6-31G**` / `6-31G(d,p)`.

## Verification

```python
import basis_set_exchange as bse
# Before fix: KeyError
# After fix:
bse.get_basis('6-31G(d)', elements=['C'])  # works
bse.get_basis('6-31G*', elements=['C'])    # still works
```