### PR TITLE
Fix ECP reader KeyError for '-ELEM' headers in gaussian94 format (fixes #363)

### DIFF
--- a/basis_set_exchange/readers/g94.py
+++ b/basis_set_exchange/readers/g94.py
@@ -154,6 +154,8 @@ def _parse_ecp_lines(basis_lines, bs_data):
 
     # First line is "{element} 0", with the zero being optional
     element_sym = basis_lines[0].split()[0]
+    # Strip leading '-' used by Gaussian94 system-library format (fixes #363)
+    element_sym = element_sym.lstrip('-')
     element_Z = lut.element_Z_from_sym(element_sym, as_str=True)
     element_data = manip.create_element_data(bs_data, element_Z, 'ecp_potentials')
 


### PR DESCRIPTION
## Problem

Fixes #363.

`bse convert-basis` fails with `KeyError: "No element data for symbol '-RB'"` when
converting a Gaussian94-format basis file that contains ECPs.

The root cause is in `_parse_ecp_lines()` in `basis_set_exchange/readers/g94.py`:

```python
element_sym = basis_lines[0].split()[0]          # may be '-RB'
element_Z = lut.element_Z_from_sym(element_sym)  # KeyError: '-RB'
```

The Gaussian94 **system-library** format uses a leading `'-'` on element headers
(e.g. `'-RB     0'`) to suppress the "element not in molecule" Gaussian error.
The `_parse_electron_shells()` function already handles this correctly:

```python
# line 64-67 in g94.py
# In the format, if the element symbol starts with a dash, then Gaussian does not crash
# with an error in case this element does not exist in the molecule input
element_sym = element_sym.lstrip('-')
```

The ECP reader has no equivalent strip.

## Fix

Add `element_sym = element_sym.lstrip('-')` after reading the symbol in
`_parse_ecp_lines()`, consistent with the existing pattern in `_parse_electron_shells()`.

## Verification

```
KeyError: "No element data for symbol '-RB'"  →  No error (Rb ECP parsed correctly)
```

Tested with the ma-SVP basis set from the original issue report (G94 format
with ECP for Rb and other heavy elements).
