### PR TITLE
fix: use hij=False for ECP lmax notation to be compatible with ORCA 6.1+ (#366)

### DIFF
--- a/basis_set_exchange/writers/orca.py
+++ b/basis_set_exchange/writers/orca.py
@@ -43,7 +43,7 @@ def write_orca_ecp_basis(basis, ecp_elements):
         data = basis['elements'][z]
         sym = lut.element_sym_from_Z(z).upper()
         max_ecp_am = max([x['angular_momentum'][0] for x in data['ecp_potentials']])
-        max_ecp_amchar = lut.amint_to_char([max_ecp_am], hij=True)
+        max_ecp_amchar = lut.amint_to_char([max_ecp_am], hij=False)  # ORCA 6.1+ rejects j-functions
 
         # Sort lowest->highest
         ecp_list = sorted(data['ecp_potentials'], key=lambda x: x['angular_momentum'])


### PR DESCRIPTION
## Problem

ORCA 6.1 changed its angular momentum spectroscopic notation to skip 'j'
functions ([manual §2.14.4 Angular Momentum Limits](https://www.faccts.de/docs/orca/6.1/manual/contents/essentialelements/integralhandling.html#angular-momentum-limits)):

```
l =  0  1  2  3  4  5  6  7  8  9  10
     S  P  D  F  G  H  I  K  L  M   N
```

ORCA 6.1+ will **reject** any input that uses `j`/`J` for angular momentum.

In `basis_set_exchange/writers/orca.py`, the ECP `lmax` header line is written using:

```python
# line 45 (before fix)
max_ecp_amchar = lut.amint_to_char([max_ecp_am], hij=True)
```

With `hij=True`, `amint_to_char` maps l=7 → `'j'`, which ORCA 6.1+ rejects.
The ECP shell entries on line 64 already use `hij=False` (l=7 → `'k'`), creating
an inconsistency: the `lmax` header could contain 'j' while the shell entries
use 'k'.

## Fix

Change line 45 to `hij=False`:

```python
max_ecp_amchar = lut.amint_to_char([max_ecp_am], hij=False)
```

This makes the `lmax` header consistent with the shell entries and compatible with
ORCA 6.1+. With `hij=False`, l=7 → `'k'` (correct ORCA 6.1 symbol).

## Impact

No current BSE 0.12 basis set has l≥7 ECP components, so this is a latent fix
that future-proofs the ORCA writer for heavy-element ECPs.

**Note (l=8 edge case):** ORCA 6.1 reserves 'L' for combined SP shells; l=8
with `hij=False` produces 'l'. Should any future basis set require l=8 ECP
potentials, that case would need the numeral `'8'` rather than a letter. This
is noted for completeness; it is not addressed in this PR.

Closes #366 (partially — documents and fixes the l=7/j case).
