### PR TITLE
Add --no-header as alias for --noheader in bse get-basis CLI (fixes #343)

### DIFF
--- a/basis_set_exchange/cli/bse_cli.py
+++ b/basis_set_exchange/cli/bse_cli.py
@@ -144,7 +144,7 @@ def run_bse_cli():
     subp.add_argument('--elements',
                       help='Which elements of the basis set to output. Default is all defined in the given basis')
     subp.add_argument('--version', help='Which version of the basis set to output. Default is the latest version')
-    subp.add_argument('--noheader', action='store_true', help='Do not output the header at the top')
+    subp.add_argument('--noheader', '--no-header', action='store_true', help='Do not output the header at the top')
     subp.add_argument('--unc-gen', action='store_true', help='Remove general contractions')
     subp.add_argument('--unc-spdf', action='store_true', help='Remove combined sp, spd, ... contractions')
     subp.add_argument('--unc-seg', action='store_true', help='Remove general contractions')


### PR DESCRIPTION
## Problem

Fixes #343.

The `bse get-basis` CLI accepts `--noheader` to suppress the basis set header.
Many command-line tools use hyphenated flags (`--no-header`) as a convention.
Currently only `--noheader` (no hyphen) is accepted; `--no-header` raises
`error: unrecognized arguments`.

## Fix

Add `'--no-header'` as a second option string for the same argument:

```python
# Before
subp.add_argument('--noheader', action='store_true', ...)

# After
subp.add_argument('--noheader', '--no-header', action='store_true', ...)
```

Both `--noheader` and `--no-header` now set `args.noheader = True`.
No other code changes required; argparse handles the dispatch automatically.
