### PR TITLE
Add '-' to elements for g94 system library ECP blocks

### DIFF
--- a/basis_set_exchange/readers/g94.py
+++ b/basis_set_exchange/readers/g94.py
@@ -154,6 +154,10 @@ def _parse_ecp_lines(basis_lines, bs_data):
 
     # First line is "{element} 0", with the zero being optional
     element_sym = basis_lines[0].split()[0]
+
+    # Similar to above - the prefixed '-' is for a system library
+    element_sym = element_sym.lstrip('-')
+
     element_Z = lut.element_Z_from_sym(element_sym, as_str=True)
     element_data = manip.create_element_data(bs_data, element_Z, 'ecp_potentials')
 

--- a/basis_set_exchange/writers/g94.py
+++ b/basis_set_exchange/writers/g94.py
@@ -95,7 +95,7 @@ def _write_g94_common(basis, add_harm_type, psi4_am, system_library):
             ecp_list = sorted(data['ecp_potentials'], key=lambda x: x['angular_momentum'])
             ecp_list.insert(0, ecp_list.pop())
 
-            s += '{}     0\n'.format(sym)
+            s += '{}{}     0\n'.format('-' if system_library else '', sym)
             s += '{}-ECP     {}     {}\n'.format(sym, max_ecp_am, data['ecp_electrons'])
 
             for pot in ecp_list:


### PR DESCRIPTION
Gaussian system libraries need a `-` prefix for the elements for both the electron shells and ECP blocks. This was missing previously.

Also adds code in the reader to tolerate the prefix when reading ECPs.

Fixes issue #338 (writer) and #363 (reader)